### PR TITLE
feat: Implement work order, scheduling, and UI enhancements

### DIFF
--- a/Components/Layout/NavMenu.razor
+++ b/Components/Layout/NavMenu.razor
@@ -59,6 +59,7 @@
         <MudNavGroup Text="Schedule" Icon="@Icons.Material.Filled.EventNote" Title="Scheduling">
             <MudNavLink Href="/schedule/ctl" Icon="@Icons.Material.Filled.CalendarToday">CTL</MudNavLink>
             <MudNavLink Href="/schedule/slitter" Icon="@Icons.Material.Filled.CalendarViewDay">Slitter</MudNavLink>
+            <MudNavLink Href="/schedule/pulling" Icon="@Icons.Material.Filled.PanTool">Pulling</MudNavLink>
             <MudNavLink Href="/schedule/loads" Icon="@Icons.Material.Filled.LocalShipping">Loads</MudNavLink>
             <MudNavLink Href="/routes" Icon="@Icons.Material.Filled.Route">Routes</MudNavLink>
         </MudNavGroup>

--- a/Components/Pages/Operations/Pickinglist/PickingLists.razor
+++ b/Components/Pages/Operations/Pickinglist/PickingLists.razor
@@ -22,9 +22,20 @@
         <MudText Typo="Typo.h5">Picking Lists</MudText>
         <AuthorizeView Policy="@Permissions.PickingLists.Add">
             <Authorized Context="authAdd">
-                <MudButton Color="Color.Primary" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Add" OnClick="Add">
-                    New
-                </MudButton>
+                <MudStack Row="true">
+                    <MudButton Color="Color.Primary"
+                               Variant="Variant.Outlined"
+                               StartIcon="@Icons.Material.Filled.UploadFile"
+                               Href="/picking-lists/upload">
+                        Upload PDF
+                    </MudButton>
+                    <MudButton Color="Color.Primary"
+                               Variant="Variant.Filled"
+                               StartIcon="@Icons.Material.Filled.Add"
+                               OnClick="Add">
+                        New
+                    </MudButton>
+                </MudStack>
             </Authorized>
         </AuthorizeView>
     </MudStack>

--- a/Components/Pages/Operations/WorkOrder/SelectPickingListDialog.razor
+++ b/Components/Pages/Operations/WorkOrder/SelectPickingListDialog.razor
@@ -1,0 +1,50 @@
+@using CMetalsWS.Data
+@using CMetalsWS.Services
+@inject PickingListService PlService
+
+<MudDialog>
+    <TitleContent>
+        <MudText Typo="Typo.h6">Select Pending Picking List Items</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudTable Items="_items" T="PickingListItem" MultiSelection="true" @bind-SelectedItems="_selectedItems" Hover="true" Dense="true">
+            <HeaderContent>
+                <MudTh>SO #</MudTh>
+                <MudTh>Customer</MudTh>
+                <MudTh>Item ID</MudTh>
+                <MudTh>Description</MudTh>
+                <MudTh>Order Qty</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd DataLabel="SO #">@context.PickingList.SalesOrderNumber</MudTd>
+                <MudTd DataLabel="Customer">@context.PickingList.CustomerName</MudTd>
+                <MudTd DataLabel="Item ID">@context.ItemId</MudTd>
+                <MudTd DataLabel="Description">@context.ItemDescription</MudTd>
+                <MudTd DataLabel="Order Qty">@context.Quantity @context.Unit</MudTd>
+            </RowTemplate>
+            <NoRecordsContent>
+                <MudText>No pending picking list items found for the required materials.</MudText>
+            </NoRecordsContent>
+        </MudTable>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancel</MudButton>
+        <MudButton Color="Color.Primary" OnClick="Submit">Select</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] MudDialogInstance MudDialog { get; set; } = default!;
+    [Parameter] public List<string> RequiredItemIds { get; set; } = new();
+
+    private List<PickingListItem> _items = new();
+    private HashSet<PickingListItem> _selectedItems = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        _items = await PlService.GetPendingItemsByItemIdsAsync(RequiredItemIds);
+    }
+
+    private void Submit() => MudDialog.Close(DialogResult.Ok(_selectedItems.ToList()));
+    private void Cancel() => MudDialog.Cancel();
+}

--- a/Components/Pages/Operations/WorkOrder/WorkOrderDialog.razor
+++ b/Components/Pages/Operations/WorkOrder/WorkOrderDialog.razor
@@ -1,6 +1,11 @@
 ﻿@using CMetalsWS.Data
+@using CMetalsWS.Services
 @using MudBlazor
 @inject IDialogService DialogService
+@inject ISnackbar Snackbar
+@inject InventoryService InvService
+@inject ItemRelationshipService RelService
+@inject PickingListService PlService
 
 <MudDialog Title="@Title">
     <DialogContent>
@@ -20,7 +25,10 @@
                     }
                 </MudSelect>
 
-                <MudTextField T="string" Label="Tag Number" @bind-Value="Model.TagNumber" Required="true" />
+                <MudStack Row="true" AlignItems="AlignItems.End">
+                    <MudTextField T="string" Label="Tag Number" @bind-Value="Model.TagNumber" Required="true" />
+                    <MudButton Variant="Variant.Outlined" OnClick="SearchByTag">Search by Tag</MudButton>
+                </MudStack>
 
                 <MudDatePicker Label="Due Date" @bind-Date="DueDateValue" Required="true" />
 
@@ -134,6 +142,87 @@
         var machine = Machines.FirstOrDefault(m => m.Id == Model.MachineId);
         if (machine != null)
             Model.MachineCategory = machine.Category;
+    }
+
+    private async Task SearchByTag()
+    {
+        if (string.IsNullOrWhiteSpace(Model.TagNumber))
+        {
+            Snackbar.Add("Please enter a Tag Number.", Severity.Warning);
+            return;
+        }
+
+        try
+        {
+            var parent = await InvService.GetByTagNumberAsync(Model.TagNumber);
+            if (parent is null)
+            {
+                Snackbar.Add($"Tag '{Model.TagNumber}' not found.", Severity.Error);
+                return;
+            }
+
+            var (_, children) = await RelService.GetAsync(parent.ItemId);
+            if (children.Count == 0)
+            {
+                Snackbar.Add($"No child items (sheets) are related to the coil with tag '{Model.TagNumber}'. Use the 'Item Relationships' page to add some.", Severity.Info);
+                return;
+            }
+
+            var childItemIds = children.Select(c => c.childId).ToList();
+            var childInventoryItems = (await InvService.GetByItemIdsAsync(childItemIds))
+                .ToDictionary(i => i.ItemId);
+
+            Model.Items.Clear();
+            foreach (var childRel in children)
+            {
+                if (childInventoryItems.TryGetValue(childRel.childId, out var childInv))
+                {
+                    Model.Items.Add(new WorkOrderItem
+                    {
+                        ItemCode = childInv.ItemId,
+                        Description = childInv.Description,
+                        Width = childInv.Width,
+                        Length = childInv.Length,
+                        // Other properties like SalesOrderNumber will be populated from picking lists next
+                    });
+                }
+            }
+
+            Snackbar.Add($"Found {Model.Items.Count} child item(s) for Tag '{Model.TagNumber}'.", Severity.Success);
+
+            // Now, ask the user to select which pending orders to associate
+            if (Model.Items.Any())
+            {
+                var parameters = new DialogParameters
+                {
+                    ["RequiredItemIds"] = childItemIds
+                };
+                var dialog = await DialogService.ShowAsync<SelectPickingListDialog>("Select Picking List Items", parameters);
+                var result = await dialog.Result;
+
+                if (!result.Canceled && result.Data is List<PickingListItem> selectedPlItems)
+                {
+                    foreach (var woItem in Model.Items)
+                    {
+                        var matchingPlItem = selectedPlItems.FirstOrDefault(p => p.ItemId == woItem.ItemCode);
+                        if (matchingPlItem != null)
+                        {
+                            woItem.SalesOrderNumber = matchingPlItem.PickingList.SalesOrderNumber;
+                            woItem.CustomerName = matchingPlItem.PickingList.CustomerName;
+                            woItem.OrderQuantity = matchingPlItem.Quantity;
+                            woItem.OrderWeight = matchingPlItem.Weight;
+                        }
+                    }
+                    Snackbar.Add($"Associated {selectedPlItems.Count} picking list item(s).", Severity.Success);
+                }
+            }
+
+            StateHasChanged();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"An error occurred: {ex.Message}", Severity.Error);
+        }
     }
 
     private void Cancel() => MudDialog.Cancel();

--- a/Components/Pages/Schedule/CtlSchedule.razor
+++ b/Components/Pages/Schedule/CtlSchedule.razor
@@ -27,49 +27,52 @@
             </MudSelect>
         </MudStack>
 
-        <MudCalendar T="SchedItem"
-                     Items="_items"
-                     View="_view"
-                     StartHour="_startHour"
-                     EndHour="_endHour"
-                     MonthCellMinHeight="120"
-                     EnableDragItems="true"
-                     EnableResizeItems="true"
-                     CanDragItem="@(it => it.Start >= DateTime.Now)"
-                     CanDropItem="@((it, date, view) => (view == CalendarView.Month && date.Add(it.Start.TimeOfDay) >= DateTime.Now) || date >= DateTime.Now)"
-                     OnItemDrop="HandleDrop"
-                     OnItemClick="HandleClick">
-            <CellTemplate Context="evt">
-                @{
-                    var wo = evt.WorkOrder!;
-                    var stripe = "var(--mud-palette-primary)";
-                    var sub = $"{wo.TagNumber} • Due {wo.DueDate:yyyy-MM-dd}";
-                }
-                <div style="width:100%;border:1px solid var(--mud-palette-lines-default);border-left:4px solid @stripe;border-radius:6px;overflow:hidden;">
-                    <div style="display:flex;align-items:center;gap:.5rem;padding:.25rem .5rem;">
-                        <MudIcon Icon="@Icons.Material.Filled.Build" Size="Size.Small" />
-                        <MudText Typo="Typo.body2">@wo.WorkOrderNumber</MudText>
-                        <MudSpacer />
-                        <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">WO @wo.Id</MudChip>
-                    </div>
-                    <div style="padding:0 .5rem .5rem .5rem;">
-                        <MudText Typo="Typo.caption">@sub</MudText>
-                    </div>
-                </div>
-            </CellTemplate>
-        </MudCalendar>
-
-        <MudDivider Class="my-4" />
-
-        <MudText Typo="Typo.h6">Unscheduled CTL Work Orders</MudText>
-        <MudList T="WorkOrder" Dense="true">
-            @foreach (var wo in _unscheduled)
-            {
-                <MudListItem T="WorkOrder" Value="@wo">
-                        @wo.WorkOrderNumber - @wo.TagNumber - Due: @wo.DueDate.ToString("yyyy-MM-dd")
-                </MudListItem>
-            }
-        </MudList>
+        <MudGrid>
+            <MudItem xs="12" sm="9">
+                <MudCalendar T="SchedItem"
+                             Items="_items"
+                             View="_view"
+                             StartHour="_startHour"
+                             EndHour="_endHour"
+                             MonthCellMinHeight="120"
+                             EnableDragItems="true"
+                             EnableResizeItems="true"
+                             CanDragItem="@(it => it.Start >= DateTime.Now)"
+                             CanDropItem="@((it, date, view) => (view == CalendarView.Month && date.Add(it.Start.TimeOfDay) >= DateTime.Now) || date >= DateTime.Now)"
+                             OnItemDrop="HandleDrop"
+                             OnItemClick="HandleClick">
+                    <CellTemplate Context="evt">
+                        @{
+                            var wo = evt.WorkOrder!;
+                            var stripe = "var(--mud-palette-primary)";
+                            var sub = $"{wo.TagNumber} • Due {wo.DueDate:yyyy-MM-dd}";
+                        }
+                        <div style="width:100%;border:1px solid var(--mud-palette-lines-default);border-left:4px solid @stripe;border-radius:6px;overflow:hidden;">
+                            <div style="display:flex;align-items:center;gap:.5rem;padding:.25rem .5rem;">
+                                <MudIcon Icon="@Icons.Material.Filled.Build" Size="Size.Small" />
+                                <MudText Typo="Typo.body2">@wo.WorkOrderNumber</MudText>
+                                <MudSpacer />
+                                <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">WO @wo.Id</MudChip>
+                            </div>
+                            <div style="padding:0 .5rem .5rem .5rem;">
+                                <MudText Typo="Typo.caption">@sub</MudText>
+                            </div>
+                        </div>
+                    </CellTemplate>
+                </MudCalendar>
+            </MudItem>
+            <MudItem xs="12" sm="3">
+                <MudText Typo="Typo.h6">Unscheduled CTL Work Orders</MudText>
+                <MudList T="WorkOrder" Dense="true">
+                    @foreach (var wo in _unscheduled)
+                    {
+                        <MudListItem T="WorkOrder" Value="@wo">
+                            @wo.WorkOrderNumber - @wo.TagNumber - Due: @wo.DueDate.ToString("yyyy-MM-dd")
+                        </MudListItem>
+                    }
+                </MudList>
+            </MudItem>
+        </MudGrid>
     </MudStack>
 </MudPaper>
 
@@ -124,9 +127,8 @@
 
     private async Task LoadWorkOrders(int? branchId)
     {
-        _all = (await WorkOrderService.GetAsync(branchId))
-            .Where(w => w.MachineCategory == MachineCategory.CTL
-                        && (_selectedMachineId == 0 || w.MachineId == _selectedMachineId))
+        _all = (await WorkOrderService.GetByCategoryAsync(MachineCategory.CTL, branchId))
+            .Where(w => _selectedMachineId == 0 || w.MachineId == _selectedMachineId)
             .ToList();
 
         _unscheduled = _all.Where(w => w.ScheduledStartDate == null).ToList();

--- a/Components/Pages/Schedule/PullingSchedule.razor
+++ b/Components/Pages/Schedule/PullingSchedule.razor
@@ -1,4 +1,4 @@
-﻿@page "/schedule/slitter"
+@page "/schedule/pulling"
 @using System.Linq
 @using MudBlazor
 @using Heron.MudCalendar
@@ -6,8 +6,7 @@
 @using CMetalsWS.Data
 @using CMetalsWS.Services
 
-@inject WorkOrderService WorkOrderService
-@inject MachineService MachineService
+@inject PickingListService PickingListService
 @inject BranchService BranchService
 @inject AuthenticationStateProvider AuthStateProvider
 @inject NavigationManager NavigationManager
@@ -17,14 +16,7 @@
 <MudPaper Class="pa-4">
     <MudStack Spacing="3">
         <MudStack Row AlignItems="AlignItems.Center" Spacing="2">
-            <MudText Typo="Typo.h5">Slitter Schedule</MudText>
-            <MudSpacer />
-            <MudSelect T="int" Label="Machine" @bind-Value="_selectedMachineId" Dense="true" Style="min-width:240px">
-                @foreach (var m in _machines)
-                {
-                    <MudSelectItem T="int" Value="@m.Id">@m.Name</MudSelectItem>
-                }
-            </MudSelect>
+            <MudText Typo="Typo.h5">Pulling Schedule</MudText>
         </MudStack>
 
         <MudGrid>
@@ -43,16 +35,16 @@
                              OnItemClick="HandleClick">
                     <CellTemplate Context="evt">
                         @{
-                            var wo = evt.WorkOrder!;
-                            var stripe = "var(--mud-palette-secondary)";
-                            var sub = $"{wo.TagNumber} • Due {wo.DueDate:yyyy-MM-dd}";
+                            var pl = evt.PickingList!;
+                            var stripe = "var(--mud-palette-info)";
+                            var sub = $"{pl.CustomerName} • Due {pl.ShipDate:yyyy-MM-dd}";
                         }
                         <div style="width:100%;border:1px solid var(--mud-palette-lines-default);border-left:4px solid @stripe;border-radius:6px;overflow:hidden;">
                             <div style="display:flex;align-items:center;gap:.5rem;padding:.25rem .5rem;">
-                                <MudIcon Icon="@Icons.Material.Filled.ContentCut" Size="Size.Small" />
-                                <MudText Typo="Typo.body2">@wo.WorkOrderNumber</MudText>
+                                <MudIcon Icon="@Icons.Material.Filled.PanTool" Size="Size.Small" />
+                                <MudText Typo="Typo.body2">@pl.SalesOrderNumber</MudText>
                                 <MudSpacer />
-                                <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">WO @wo.Id</MudChip>
+                                <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">PL @pl.Id</MudChip>
                             </div>
                             <div style="padding:0 .5rem .5rem .5rem;">
                                 <MudText Typo="Typo.caption">@sub</MudText>
@@ -62,12 +54,12 @@
                 </MudCalendar>
             </MudItem>
             <MudItem xs="12" sm="3">
-                <MudText Typo="Typo.h6">Unscheduled Slitter Work Orders</MudText>
-                <MudList T="WorkOrder" Dense="true">
-                    @foreach (var wo in _unscheduled)
+                <MudText Typo="Typo.h6">Unscheduled Pulling Orders</MudText>
+                <MudList T="PickingList" Dense="true">
+                    @foreach (var pl in _unscheduled)
                     {
-                        <MudListItem T="WorkOrder" Value="@wo">
-                            @wo.WorkOrderNumber - @wo.TagNumber - Due: @wo.DueDate.ToString("yyyy-MM-dd")
+                        <MudListItem T="PickingList" Value="@pl">
+                            @pl.SalesOrderNumber - @pl.CustomerName - Due: @pl.ShipDate?.ToString("yyyy-MM-dd")
                         </MudListItem>
                     }
                 </MudList>
@@ -79,15 +71,13 @@
 @code {
     private sealed class SchedItem : CalendarItem
     {
-        public WorkOrder WorkOrder { get; init; } = default!;
+        public PickingList PickingList { get; init; } = default!;
     }
 
-    private List<Machine> _machines = new();
-    private List<WorkOrder> _all = new();
-    private List<WorkOrder> _unscheduled = new();
+    private List<PickingList> _all = new();
+    private List<PickingList> _unscheduled = new();
     private List<SchedItem> _items = new();
 
-    private int _selectedMachineId;
     private CalendarView _view = CalendarView.Week;
     private int _startHour = 5;
     private int _endHour = 23;
@@ -100,14 +90,7 @@
         var branches = await BranchService.GetBranchesAsync();
         int? branchId = user.IsInRole("Admin") ? null : branches.FirstOrDefault()?.Id;
 
-        _machines = (await MachineService.GetMachinesAsync())
-            .Where(m => m.Category == MachineCategory.Slitter && (!branchId.HasValue || m.BranchId == branchId.Value))
-            .ToList();
-
-        if (_machines.Any())
-            _selectedMachineId = _machines.First().Id;
-
-        await LoadWorkOrders(branchId);
+        await LoadPickingLists(branchId);
         BuildCalendarItems();
 
         _hub = new HubConnectionBuilder()
@@ -115,9 +98,9 @@
             .WithAutomaticReconnect()
             .Build();
 
-        _hub.On<int>("WorkOrderUpdated", async (id) =>
+        _hub.On<int>("PickingListUpdated", async (id) =>
         {
-            await LoadWorkOrders(branchId);
+            await LoadPickingLists(branchId);
             BuildCalendarItems();
             StateHasChanged();
         });
@@ -125,26 +108,23 @@
         await _hub.StartAsync();
     }
 
-    private async Task LoadWorkOrders(int? branchId)
+    private async Task LoadPickingLists(int? branchId)
     {
-        _all = (await WorkOrderService.GetByCategoryAsync(MachineCategory.Slitter, branchId))
-            .Where(w => _selectedMachineId == 0 || w.MachineId == _selectedMachineId)
-            .ToList();
-
-        _unscheduled = _all.Where(w => w.ScheduledStartDate == null).ToList();
+        _all = await PickingListService.GetPendingPullingOrdersAsync(branchId);
+        _unscheduled = _all.Where(p => p.ShipDate == null || p.ShipDate.Value.Date < DateTime.Today).ToList();
     }
 
     private void BuildCalendarItems()
     {
         _items = _all
-            .Where(w => w.ScheduledStartDate != null)
-            .Select(w => new SchedItem
+            .Where(p => p.ShipDate != null && p.ShipDate.Value.Date >= DateTime.Today)
+            .Select(p => new SchedItem
             {
-                Text = w.WorkOrderNumber,
-                Start = w.ScheduledStartDate!.Value,
-                End = w.ScheduledEndDate ?? w.ScheduledStartDate!.Value.AddHours(1),
+                Text = p.SalesOrderNumber,
+                Start = p.ShipDate!.Value,
+                End = p.ShipDate!.Value.AddHours(1),
                 AllDay = false,
-                WorkOrder = w
+                PickingList = p
             })
             .ToList();
     }
@@ -154,24 +134,23 @@
         dynamic d = e;
         var item = (SchedItem)d.Item;
         var newStart = (DateTime)d.NewStart;
-        var newEnd = (DateTime?)(d.NewEnd ?? null) ?? newStart.AddHours(1);
 
-        var wo = item.WorkOrder;
-        wo.ScheduledStartDate = newStart;
-        wo.ScheduledEndDate = newEnd;
+        var pl = item.PickingList;
+        pl.ShipDate = newStart;
 
-        await WorkOrderService.UpdateAsync(wo, "system");
-        await LoadWorkOrders(null);
+        await PickingListService.ScheduleListAsync(pl.Id, newStart);
+        await LoadPickingLists(null);
         BuildCalendarItems();
         StateHasChanged();
 
         if (_hub is not null)
-            await _hub.SendAsync("WorkOrderUpdated", wo.Id);
+            await _hub.SendAsync("PickingListUpdated", pl.Id);
     }
 
     private Task HandleClick(SchedItem item)
     {
-        // NavigationManager.NavigateTo($"/work-orders/{item.WorkOrder.Id}");
+        // For consistency, could navigate to a picking list detail view
+        // NavigationManager.NavigateTo($"/picking-lists/{item.PickingList.Id}");
         return Task.CompletedTask;
     }
 

--- a/Services/InventoryService.cs
+++ b/Services/InventoryService.cs
@@ -8,6 +8,28 @@ namespace CMetalsWS.Services
         private readonly ApplicationDbContext _db;
         public InventoryService(ApplicationDbContext db) => _db = db;
 
+        public async Task<InventoryItem?> GetByTagNumberAsync(string tagNumber, CancellationToken ct = default)
+        {
+            tagNumber = tagNumber?.Trim() ?? "";
+            if (string.IsNullOrWhiteSpace(tagNumber))
+                return null;
+
+            return await _db.InventoryItems
+                .AsNoTracking()
+                .FirstOrDefaultAsync(i => i.TagNumber == tagNumber, ct);
+        }
+
+        public async Task<List<InventoryItem>> GetByItemIdsAsync(List<string> itemIds, CancellationToken ct = default)
+        {
+            if (itemIds == null || itemIds.Count == 0)
+                return new List<InventoryItem>();
+
+            return await _db.InventoryItems
+                .AsNoTracking()
+                .Where(i => itemIds.Contains(i.ItemId))
+                .ToListAsync(ct);
+        }
+
         // Upsert by (BranchId, TagNumber)
         public async Task<(int inserted, int updated)> UpsertAsync(IEnumerable<InventoryItem> rows, CancellationToken ct = default)
         {

--- a/Services/WorkOrderService.cs
+++ b/Services/WorkOrderService.cs
@@ -34,6 +34,22 @@ namespace CMetalsWS.Services
                 .ToListAsync();
         }
 
+        public async Task<List<WorkOrder>> GetByCategoryAsync(MachineCategory category, int? branchId = null)
+        {
+            IQueryable<WorkOrder> query = _db.WorkOrders
+                .Include(w => w.Items)
+                .Include(w => w.Machine)
+                .Where(w => w.MachineCategory == category)
+                .AsNoTracking();
+
+            if (branchId.HasValue)
+                query = query.Where(w => w.BranchId == branchId.Value);
+
+            return await query
+                .OrderByDescending(w => w.CreatedDate)
+                .ToListAsync();
+        }
+
         public async Task<WorkOrder?> GetByIdAsync(int id)
         {
             return await _db.WorkOrders


### PR DESCRIPTION
This commit delivers several enhancements to the CMetals warehousing system based on user requirements.

Key features include:
- PDF Upload Link: Added a button to the Picking Lists page to provide access to the existing PDF upload feature.
- Enhanced Work Order Flow: Reworked the work order creation process. It is now driven by a coil's `Tag Number`, which automatically looks up and populates related child items (sheets) and allows the user to associate them with pending picking lists.
- New & Improved Scheduling Calendars:
  - Created a new "Pulling Schedule" for scheduling in-stock picking lists.
  - Refactored the CTL and Slitter schedules for improved data loading efficiency.
  - Updated the UI for all three scheduling pages to a side-by-side layout, placing the calendar next to the list of unscheduled items for easier drag-and-drop.