### PR TITLE
feat: Add WorkOrder details view and restrict to user's branch

### DIFF
--- a/Components/Pages/Operations/WorkOrder/WorkOrderDetailsDialog.razor
+++ b/Components/Pages/Operations/WorkOrder/WorkOrderDetailsDialog.razor
@@ -1,0 +1,72 @@
+@using CMetalsWS.Data
+@using CMetalsWS.Services
+@using MudBlazor
+@inject InventoryService InvService
+
+<MudDialog Title="Work Order Details">
+    <DialogContent>
+        <MudForm>
+            <MudStack Spacing="3">
+                <MudCard>
+                    <MudCardHeader><CardHeaderContent><MudText Typo="Typo.h6">Pull Info</MudText></CardHeaderContent></MudCardHeader>
+                    <MudCardContent>
+                        <MudGrid>
+                            <MudItem xs="12" sm="6"><MudText><b>Tag Number:</b> @Model.TagNumber</MudText></MudItem>
+                            <MudItem xs="12" sm="6"><MudText><b>Weight:</b> @_parentItem?.Snapshot</MudText></MudItem>
+                            <MudItem xs="12" sm="6"><MudText><b>Location:</b> @_parentItem?.Location</MudText></MudItem>
+                            <MudItem xs="12" sm="6"><MudText><b>Description:</b> @_parentItem?.Description</MudText></MudItem>
+                        </MudGrid>
+                    </MudCardContent>
+                </MudCard>
+
+                <MudCard>
+                    <MudCardHeader><CardHeaderContent><MudText Typo="Typo.h6">Picking List</MudText></CardHeaderContent></MudCardHeader>
+                    <MudCardContent>
+                        <MudTable Items="Model.Items" Dense="true" Hover="true">
+                            <HeaderContent>
+                                <MudTh>Sales Order #</MudTh>
+                                <MudTh>Customer</MudTh>
+                                <MudTh>Order Quantity</MudTh>
+                                <MudTh>Length</MudTh>
+                                <MudTh>Width</MudTh>
+                            </HeaderContent>
+                            <RowTemplate>
+                                <MudTd DataLabel="Sales Order #">@context.SalesOrderNumber</MudTd>
+                                <MudTd DataLabel="Customer">@context.CustomerName</MudTd>
+                                <MudTd DataLabel="Order Quantity">@context.OrderQuantity</MudTd>
+                                <MudTd DataLabel="Length">@context.Length</MudTd>
+                                <MudTd DataLabel="Width">@context.Width</MudTd>
+                            </RowTemplate>
+                        </MudTable>
+                    </MudCardContent>
+                </MudCard>
+            </MudStack>
+        </MudForm>
+    </DialogContent>
+    <DialogActions>
+        <MudButton Variant="Variant.Text" OnClick="Cancel">Close</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Edit">Edit</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] public IMudDialogInstance MudDialog { get; set; } = default!;
+    [Parameter] public WorkOrder Model { get; set; } = new();
+
+    private InventoryItem? _parentItem;
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (!string.IsNullOrEmpty(Model.TagNumber))
+        {
+            _parentItem = await InvService.GetByTagNumberAsync(Model.TagNumber);
+        }
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+
+    private void Edit()
+    {
+        MudDialog.Close(DialogResult.Ok(true));
+    }
+}

--- a/Components/Pages/Operations/WorkOrder/WorkOrders.razor
+++ b/Components/Pages/Operations/WorkOrder/WorkOrders.razor
@@ -54,6 +54,7 @@
             <MudTd>@(context.ScheduledEndDate.ToString("yyyy-MM-dd HH:mm"))</MudTd>
             <MudTd>
                 <MudMenu Icon="@Icons.Material.Filled.MoreVert" Dense="true">
+                    <MudMenuItem OnClick="@(() => ViewWorkOrderAsync(context))">Details</MudMenuItem>
                     <AuthorizeView Policy="@Permissions.WorkOrders.Edit" Context="auth">
                         <MudMenuItem OnClick="@(() => EditWorkOrderAsync(context))">Edit</MudMenuItem>
                     </AuthorizeView>
@@ -71,7 +72,6 @@
     private string _searchString = "";
     private List<Machine> _machines = new();
     private List<Branch> _branches = new();
-    private bool _isAdmin;
     private int? _userBranchId;
     private HubConnection? _hubConnection;
 
@@ -87,7 +87,6 @@
     {
         var auth = await AuthStateProvider.GetAuthenticationStateAsync();
         var user = await UserManager.GetUserAsync(auth.User);
-        _isAdmin = auth.User.IsInRole("Admin");
         _userBranchId = user?.BranchId;
 
         _machines = await MachineService.GetMachinesAsync();
@@ -113,7 +112,7 @@
 
     private async Task LoadAsync()
     {
-        var branchFilter = _isAdmin ? null : _userBranchId;
+        var branchFilter = _userBranchId;
         _workOrders = await WorkOrderService.GetAsync(branchFilter);
         StateHasChanged();
     }
@@ -153,6 +152,21 @@
                 Snackbar.Add("Work order created.", Severity.Success);
                 await LoadAsync();
             }
+        }
+    }
+    private async Task ViewWorkOrderAsync(WorkOrder wo)
+    {
+        var parameters = new DialogParameters
+        {
+            ["Model"] = wo
+        };
+
+        var dialog = await DialogService.ShowAsync<WorkOrderDetailsDialog>("Work Order Details", parameters, new DialogOptions { MaxWidth = MaxWidth.Medium, FullWidth = true });
+        var result = await dialog.Result;
+
+        if (result is not null && !result.Canceled && result.Data is bool shouldEdit && shouldEdit)
+        {
+            await EditWorkOrderAsync(wo);
         }
     }
 

--- a/Components/Pages/Schedule/MachineScheduleBase.razor
+++ b/Components/Pages/Schedule/MachineScheduleBase.razor
@@ -4,12 +4,15 @@
 @using Microsoft.AspNetCore.SignalR.Client
 @using CMetalsWS.Data
 @using CMetalsWS.Services
+@using CMetalsWS.Components.Pages.Operations.WorkOrder
 @using MudBlazor.Utilities
 
+@using Microsoft.AspNetCore.Identity
 @inject WorkOrderService WorkOrderService
 @inject MachineService MachineService
 @inject BranchService BranchService
 @inject AuthenticationStateProvider AuthStateProvider
+@inject UserManager<ApplicationUser> UserManager
 @inject NavigationManager NavigationManager
 @inject ISnackbar Snackbar
 @inject IDialogService DialogService
@@ -64,11 +67,11 @@
     protected override async Task OnInitializedAsync()
     {
         var auth = await AuthStateProvider.GetAuthenticationStateAsync();
-        var user = auth.User;
-        var branches = await BranchService.GetBranchesAsync();
-        var branchId = user.IsInRole("Admin") ? (int?)null : branches.FirstOrDefault()?.Id;
+        var user = await UserManager.GetUserAsync(auth.User);
+        var branchId = user?.BranchId;
 
-        var branch = branches.FirstOrDefault();
+        var branches = await BranchService.GetBranchesAsync();
+        var branch = branches.FirstOrDefault(b => b.Id == branchId);
         _branchWorkHours = branch is not null && branch.StartTime.HasValue && branch.EndTime.HasValue
             ? (branch.StartTime.Value, branch.EndTime.Value)
             : (new(5,0,0), new(23,0,0));
@@ -119,13 +122,80 @@
     {
         if (item is ScheduleEvent scheduleEvent)
         {
-            var parameters = new DialogParameters<Dialogs.WorkOrderDetailsDialog>
+            var parameters = new DialogParameters
             {
-                { x => x.WorkOrderId, scheduleEvent.WorkOrder.Id },
-                { x => x.MachineCategory, this.MachineCategory }
+                ["Model"] = scheduleEvent.WorkOrder
             };
 
-            await DialogService.ShowAsync<Dialogs.WorkOrderDetailsDialog>("Work Order Details", parameters);
+            var dialog = await DialogService.ShowAsync<WorkOrderDetailsDialog>("Work Order Details", parameters, new DialogOptions { MaxWidth = MaxWidth.Medium, FullWidth = true });
+            var result = await dialog.Result;
+
+            if (result is not null && !result.Canceled && result.Data is bool shouldEdit && shouldEdit)
+            {
+                await EditWorkOrderAsync(scheduleEvent.WorkOrder);
+            }
+        }
+    }
+
+    private async Task EditWorkOrderAsync(WorkOrder wo)
+    {
+        var branches = await BranchService.GetBranchesAsync();
+        var clone = new WorkOrder
+        {
+            Id = wo.Id,
+            WorkOrderNumber = wo.WorkOrderNumber,
+            TagNumber = wo.TagNumber,
+            BranchId = wo.BranchId,
+            MachineId = wo.MachineId,
+            MachineCategory = wo.MachineCategory,
+            DueDate = wo.DueDate,
+            Instructions = wo.Instructions,
+            Status = wo.Status,
+            ScheduledStartDate = wo.ScheduledStartDate,
+            ScheduledEndDate = wo.ScheduledEndDate,
+            Items = wo.Items.Select(i => new WorkOrderItem
+            {
+                Id = i.Id,
+                WorkOrderId = wo.Id,
+                PickingListItemId = i.PickingListItemId,
+                ItemCode = i.ItemCode,
+                Description = i.Description,
+                SalesOrderNumber = i.SalesOrderNumber,
+                CustomerName = i.CustomerName,
+                OrderQuantity = i.OrderQuantity,
+                OrderWeight = i.OrderWeight,
+                Width = i.Width,
+                Length = i.Length,
+                ProducedQuantity = i.ProducedQuantity,
+                ProducedWeight = i.ProducedWeight,
+                Unit = i.Unit,
+                Location = i.Location
+            }).ToList()
+        };
+
+        var parameters = new DialogParameters
+        {
+            ["Model"] = clone,
+            ["Machines"] = _machines.Where(m => m.Category == MachineCategory.CTL || m.Category == MachineCategory.Slitter).ToList(),
+            ["Branches"] = branches,
+            ["Title"] = $"Edit {wo.WorkOrderNumber}",
+            ["IsEdit"] = true
+        };
+
+        var dialog = await DialogService.ShowAsync<WorkOrderDialog>("Edit Work Order", parameters, new DialogOptions { MaxWidth = MaxWidth.ExtraLarge, FullWidth = true });
+        if(dialog is not null)
+        {
+            var result = await dialog.Result;
+            if (result is not null && !result.Canceled && result.Data is WorkOrder updated)
+            {
+                var auth = await AuthStateProvider.GetAuthenticationStateAsync();
+                var user = auth.User;
+                var updatedBy = user?.Identity?.Name ?? "system";
+
+                await WorkOrderService.UpdateAsync(updated, updatedBy);
+                Snackbar.Add("Work order updated.", Severity.Success);
+                await ReloadDataAndRefresh();
+            }
         }
     }
 
@@ -150,9 +220,8 @@
     private async Task ReloadDataAndRefresh()
     {
         var auth = await AuthStateProvider.GetAuthenticationStateAsync();
-        var user = auth.User;
-        var branches = await BranchService.GetBranchesAsync();
-        var branchId = user.IsInRole("Admin") ? (int?)null : branches.FirstOrDefault()?.Id;
+        var user = await UserManager.GetUserAsync(auth.User);
+        var branchId = user?.BranchId;
         await LoadWorkOrders(branchId);
         StateHasChanged();
     }


### PR DESCRIPTION
- Created a new `WorkOrderDetailsDialog.razor` component to display work order details in a read-only view.
- The details view includes "Pull Info" (from InventoryItem) and a "Picking List" (from WorkOrderItems).
- Modified `WorkOrders.razor` and `MachineScheduleBase.razor` to open the details dialog.
- The details dialog has an "Edit" button that opens the existing `WorkOrderDialog.razor` for editing.
- Updated branch filtering logic to restrict all users to their default branch.