### PR TITLE
feat: Implement Work Order Processing Interface

### DIFF
--- a/Components/Pages/Operations/WorkOrder/WorkOrderDialog.razor
+++ b/Components/Pages/Operations/WorkOrder/WorkOrderDialog.razor
@@ -184,18 +184,21 @@
         <MudButton Variant="Variant.Text" OnClick="Cancel">Cancel</MudButton>
         @if (IsProcessing)
         {
-            @if (_lastAuditEvent == null)
+            if (Model.Status == WorkOrderStatus.Pending)
             {
-                <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@(() => HandleAuditEvent(AuditEventType.Start))" StartIcon="@Icons.Material.Filled.PlayArrow">Start</MudButton>
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="StartTaskAsync" StartIcon="@Icons.Material.Filled.PlayArrow">Start Task</MudButton>
             }
-            else if (_lastAuditEvent == AuditEventType.Start || _lastAuditEvent == AuditEventType.Resume)
+            else if (Model.Status == WorkOrderStatus.InProgress)
             {
-                <MudButton Variant="Variant.Filled" Color="Color.Warning" OnClick="@(() => HandleAuditEvent(AuditEventType.Pause))" StartIcon="@Icons.Material.Filled.Pause">Pause</MudButton>
-                <MudButton Variant="Variant.Filled" Color="Color.Success" OnClick="@(() => HandleAuditEvent(AuditEventType.Complete))" StartIcon="@Icons.Material.Filled.Done">Complete</MudButton>
-            }
-            else if (_lastAuditEvent == AuditEventType.Pause)
-            {
-                <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@(() => HandleAuditEvent(AuditEventType.Resume))" StartIcon="@Icons.Material.Filled.PlayArrow">Resume</MudButton>
+                if (_lastAuditEvent == AuditEventType.Pause)
+                {
+                    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="ResumeTaskAsync" StartIcon="@Icons.Material.Filled.PlayArrow">Resume Task</MudButton>
+                }
+                else
+                {
+                    <MudButton Variant="Variant.Filled" Color="Color.Warning" OnClick="PauseTaskAsync" StartIcon="@Icons.Material.Filled.Pause">Pause Task</MudButton>
+                }
+                <MudButton Variant="Variant.Filled" Color="Color.Success" OnClick="CompleteTaskAsync" StartIcon="@Icons.Material.Filled.Done">Complete Task</MudButton>
             }
         }
         else
@@ -481,7 +484,32 @@
         Model.Items.Remove(item);
     }
 
-    private async Task HandleAuditEvent(AuditEventType eventType)
+    private async Task StartTaskAsync()
+    {
+        Model.Status = WorkOrderStatus.InProgress;
+        await CreateAuditEventAsync(AuditEventType.Start);
+        await WorkOrderService.UpdateAsync(Model, (await AuthState).User.Identity?.Name ?? "Unknown");
+    }
+
+    private async Task PauseTaskAsync()
+    {
+        await CreateAuditEventAsync(AuditEventType.Pause);
+    }
+
+    private async Task ResumeTaskAsync()
+    {
+        await CreateAuditEventAsync(AuditEventType.Resume);
+    }
+
+    private async Task CompleteTaskAsync()
+    {
+        Model.Status = WorkOrderStatus.Completed;
+        await CreateAuditEventAsync(AuditEventType.End);
+        await WorkOrderService.UpdateAsync(Model, (await AuthState).User.Identity?.Name ?? "Unknown");
+        MudDialog.Close(DialogResult.Ok(true));
+    }
+
+    private async Task CreateAuditEventAsync(AuditEventType eventType)
     {
         var user = (await AuthState).User;
         var userId = user.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
@@ -495,23 +523,7 @@
         await AuditService.CreateAuditEventAsync(Model.Id, TaskType.WorkOrder, eventType, userId);
         _lastAuditEvent = eventType;
         Snackbar.Add($"Task successfully {eventType.ToString().ToLower()}ed.", Severity.Success);
-
-        if (eventType == AuditEventType.Complete)
-        {
-            await MarkComplete();
-        }
-        else
-        {
-            StateHasChanged();
-        }
-    }
-
-    private async Task MarkComplete()
-    {
-        var user = (await AuthState).User;
-        var updatedBy = user.Identity?.Name ?? "Unknown";
-        await WorkOrderService.MarkWorkOrderCompleteAsync(Model, updatedBy);
-        MudDialog.Close(DialogResult.Ok(Model));
+        StateHasChanged();
     }
 
     private static readonly Dictionary<int, double> GaugeLookup = new()

--- a/Components/Pages/Schedule/Dialogs/WorkOrderDetailsDialog.razor
+++ b/Components/Pages/Schedule/Dialogs/WorkOrderDetailsDialog.razor
@@ -1,16 +1,17 @@
-@using MudBlazor
 @using CMetalsWS.Data
 @using CMetalsWS.Services
+@using CMetalsWS.Security
 @using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.AspNetCore.Identity
 
 @inject WorkOrderService WorkOrderService
-@inject AuthenticationStateProvider AuthStateProvider
-@inject TaskAuditEventService AuditEventService
+@inject InventoryService InvService
+@inject IAuthorizationService AuthorizationService
 @inject ISnackbar Snackbar
 
 <MudDialog>
     <TitleContent>
-        <MudText Typo="Typo.h6">Work Order: @(_workOrder?.WorkOrderNumber)</MudText>
+        <MudText Typo="Typo.h6">Work Order Details - #@(_workOrder?.WorkOrderNumber)</MudText>
     </TitleContent>
     <DialogContent>
         @if (_workOrder == null)
@@ -21,92 +22,89 @@
         {
             <MudGrid Spacing="2">
                 <MudItem xs="12">
-                    <MudText><b>Tag Number:</b> @_workOrder.TagNumber</MudText>
+                    <MudCard>
+                        <MudCardHeader><CardHeaderContent><MudText Typo="Typo.h6">Pull Info</MudText></CardHeaderContent></MudCardHeader>
+                        <MudCardContent>
+                            <MudGrid>
+                                <MudItem xs="12" sm="6"><MudText><b>Tag Number:</b> @_workOrder.TagNumber</MudText></MudItem>
+                                <MudItem xs="12" sm="6"><MudText><b>Weight:</b> @_parentItem?.Snapshot</MudText></MudItem>
+                                <MudItem xs="12" sm="6"><MudText><b>Location:</b> @_parentItem?.Location</MudText></MudItem>
+                                <MudItem xs="12" sm="6"><MudText><b>Description:</b> @_parentItem?.Description</MudText></MudItem>
+                            </MudGrid>
+                        </MudCardContent>
+                    </MudCard>
                 </MudItem>
-
-                @foreach(var item in _workOrder.Items)
-                {
-                    <MudItem xs="12"><MudDivider /></MudItem>
-                    <MudItem xs="12">
-                        <MudText><b>Description:</b> @item.Description</MudText>
-                    </MudItem>
-                    <MudItem xs="12" sm="6">
-                        <MudText><b>Sales Order:</b> @item.SalesOrderNumber</MudText>
-                    </MudItem>
-                    <MudItem xs="12" sm="6">
-                        <MudText><b>Customer:</b> @item.CustomerName</MudText>
-                    </MudItem>
-                    <MudItem xs="12" sm="3">
-                        <MudText><b>Quantity:</b> @item.OrderQuantity</MudText>
-                    </MudItem>
-                    <MudItem xs="12" sm="3">
-                        <MudText><b>Weight:</b> @item.OrderWeight</MudText>
-
-                    </MudItem>
-                    <MudItem xs="12" sm="3">
-                        <MudText><b>Width:</b> @item.Width</MudText>
-                    </MudItem>
-
-                    @if (MachineCategory == MachineCategory.CTL)
-                    {
-                        <MudItem xs="12" sm="3">
-                            <MudText><b>Length:</b> @item.Length</MudText>
-                        </MudItem>
-                    }
-                }
+                <MudItem xs="12">
+                    <MudCard>
+                        <MudCardHeader><CardHeaderContent><MudText Typo="Typo.h6">Picking List</MudText></CardHeaderContent></MudCardHeader>
+                        <MudCardContent>
+                            <MudTable Items="_workOrder.Items" Dense="true" Hover="true">
+                                <HeaderContent>
+                                    <MudTh>Item Code</MudTh>
+                                    <MudTh>Description</MudTh>
+                                    <MudTh>Sales Order #</MudTh>
+                                    <MudTh>Customer</MudTh>
+                                    <MudTh>Order Qty</MudTh>
+                                    <MudTh>Order Wt</MudTh>
+                                    <MudTh>Width</MudTh>
+                                    <MudTh>Length</MudTh>
+                                </HeaderContent>
+                                <RowTemplate>
+                                    <MudTd DataLabel="Item Code">@context.ItemCode</MudTd>
+                                    <MudTd DataLabel="Description">@context.Description</MudTd>
+                                    <MudTd DataLabel="Sales Order #">@context.SalesOrderNumber</MudTd>
+                                    <MudTd DataLabel="Customer">@context.CustomerName</MudTd>
+                                    <MudTd DataLabel="Order Qty">@context.OrderQuantity</MudTd>
+                                    <MudTd DataLabel="Order Wt">@context.OrderWeight</MudTd>
+                                    <MudTd DataLabel="Width">@context.Width</MudTd>
+                                    <MudTd DataLabel="Length">@context.Length</MudTd>
+                                </RowTemplate>
+                            </MudTable>
+                        </MudCardContent>
+                    </MudCard>
+                </MudItem>
             </MudGrid>
         }
     </DialogContent>
     <DialogActions>
         <MudButton OnClick="Cancel">Close</MudButton>
-        <AuthorizeView Roles="Planner, Admin">
+        @if (_canEdit)
+        {
             <MudButton Color="Color.Secondary" OnClick="Edit">Edit</MudButton>
-        </AuthorizeView>
-        <AuthorizeView Roles="Operator">
+        }
+        @if (_canProcess)
+        {
             <MudButton Color="Color.Primary" OnClick="Process">Process</MudButton>
-        </AuthorizeView>
+        }
     </DialogActions>
 </MudDialog>
 
 @code {
-    [CascadingParameter] IMudDialogInstance MudDialog { get; set; } = default!;
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = default!;
+    [CascadingParameter] private Task<AuthenticationState> AuthState { get; set; } = default!;
     [Parameter] public int WorkOrderId { get; set; }
-    [Parameter] public MachineCategory MachineCategory { get; set; }
 
     private WorkOrder? _workOrder;
+    private InventoryItem? _parentItem;
+    private bool _canEdit;
+    private bool _canProcess;
 
     protected override async Task OnInitializedAsync()
     {
+        var user = (await AuthState).User;
+        _canEdit = (await AuthorizationService.AuthorizeAsync(user, Permissions.WorkOrders.Edit)).Succeeded;
+        _canProcess = (await AuthorizationService.AuthorizeAsync(user, Permissions.WorkOrders.Process)).Succeeded;
+
         _workOrder = await WorkOrderService.GetByIdAsync(WorkOrderId);
-    }
-
-    private void Edit()
-    {
-        // Logic for editing the work order would go here.
-        throw new NotImplementedException("Editing a work order is not yet implemented.");
-    }
-
-    private async Task Process()
-    {
-        if (_workOrder is null) return;
-
-        try
+        if (_workOrder != null && !string.IsNullOrEmpty(_workOrder.TagNumber))
         {
-            var authState = await AuthStateProvider.GetAuthenticationStateAsync();
-            var user = authState.User;
-            var userId = user.Identity?.Name ?? "Unknown";
-
-            await WorkOrderService.SetStatusAsync(_workOrder.Id, WorkOrderStatus.InProgress, userId);
-            await AuditEventService.CreateAuditEventAsync(_workOrder.Id, TaskType.WorkOrder, AuditEventType.Start, userId, $"Work Order {_workOrder.WorkOrderNumber} processing started.");
-
-            Snackbar.Add("Work Order processing started.", Severity.Success);
-            MudDialog.Close(DialogResult.Ok(true));
-        }
-        catch (Exception ex)
-        {
-            Snackbar.Add($"Error processing Work Order: {ex.Message}", Severity.Error);
+            _parentItem = await InvService.GetByTagNumberAsync(_workOrder.TagNumber);
         }
     }
+
+    private void Edit() => MudDialog.Close(DialogResult.Ok("edit"));
+
+    private void Process() => MudDialog.Close(DialogResult.Ok("process"));
 
     private void Cancel() => MudDialog.Cancel();
 }

--- a/Components/Pages/Schedule/MachineScheduleBase.razor
+++ b/Components/Pages/Schedule/MachineScheduleBase.razor
@@ -4,6 +4,7 @@
 @using Microsoft.AspNetCore.SignalR.Client
 @using CMetalsWS.Data
 @using CMetalsWS.Services
+@using CMetalsWS.Components.Pages.Operations.WorkOrder
 @using MudBlazor.Utilities
 
 @inject WorkOrderService WorkOrderService
@@ -117,15 +118,41 @@
 
     private async Task OnItemClicked(CalendarItem item)
     {
-        if (item is ScheduleEvent scheduleEvent)
-        {
-            var parameters = new DialogParameters<Dialogs.WorkOrderDetailsDialog>
-            {
-                { x => x.WorkOrderId, scheduleEvent.WorkOrder.Id },
-                { x => x.MachineCategory, this.MachineCategory }
-            };
+        if (item is not ScheduleEvent scheduleEvent) return;
 
-            await DialogService.ShowAsync<Dialogs.WorkOrderDetailsDialog>("Work Order Details", parameters);
+        var detailsParams = new DialogParameters { ["WorkOrderId"] = scheduleEvent.WorkOrder.Id };
+        var detailsDialog = await DialogService.ShowAsync<Dialogs.WorkOrderDetailsDialog>("Work Order Details", detailsParams);
+        var detailsResult = await detailsDialog.Result;
+
+        if (detailsResult is not null && !detailsResult.Canceled && detailsResult.Data is string action)
+        {
+            if (action == "edit" || action == "process")
+            {
+                await ShowWorkOrderDialogAsync(scheduleEvent.WorkOrder, action);
+            }
+        }
+    }
+
+    private async Task ShowWorkOrderDialogAsync(WorkOrder wo, string mode)
+    {
+        var isProcessing = mode == "process";
+        var parameters = new DialogParameters
+        {
+            ["Model"] = wo,
+            ["Machines"] = _machines,
+            ["Branches"] = await BranchService.GetBranchesAsync(),
+            ["Title"] = isProcessing ? $"Process {wo.WorkOrderNumber}" : $"Edit {wo.WorkOrderNumber}",
+            ["IsEdit"] = true, // Keep IsEdit to disable tag search
+            ["IsProcessing"] = isProcessing
+        };
+
+        var options = new DialogOptions { MaxWidth = MaxWidth.ExtraLarge, FullWidth = true, DisableBackdropClick = true };
+        var dialog = await DialogService.ShowAsync<WorkOrderDialog>(isProcessing ? "Process Work Order" : "Edit Work Order", parameters, options);
+        var result = await dialog.Result;
+
+        if (result is not null && !result.Canceled)
+        {
+            await ReloadDataAndRefresh();
         }
     }
 


### PR DESCRIPTION
- Enhanced the machine schedule pages to open a new work order details dialog on event click.
- The details dialog provides a read-only summary of the work order and allows users to either "Edit" or "Process" the work order based on their permissions.
- The main work order dialog now has a "processing mode" with a state machine for starting, pausing, resuming, and completing tasks.
- Each processing action (Start, Pause, Resume, Complete) creates a `TaskAuditEvent` to log the event.