### PR TITLE
Fix build errors and set up .NET 9 environment

### DIFF
--- a/CMetalsWS.csproj
+++ b/CMetalsWS.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.*" />
     <PackageReference Include="MiniExcel" Version="1.41.3" />
-    <PackageReference Include="MudBlazor" Version="8.*" />
+    <PackageReference Include="MudBlazor" Version="8.12.0" />
     <PackageReference Include="Extensions.MudBlazor.StaticInput" Version="3.*" />
   </ItemGroup>
 

--- a/Components/Pages/Operations/Loads/PartialShipmentDialog.razor
+++ b/Components/Pages/Operations/Loads/PartialShipmentDialog.razor
@@ -17,7 +17,7 @@
 
 @code {
     [CascadingParameter] IMudDialogInstance MudDialog { get; set; } = default!;
-    [Parameter] public PickingList PickingList { get; set; } = new();
+    [Parameter] public PickingList PickingList { get; set; }
 
     private decimal _shippedWeight;
 

--- a/Components/Pages/Operations/Pickinglist/Dialogs/PullingTaskDetailDialog.razor
+++ b/Components/Pages/Operations/Pickinglist/Dialogs/PullingTaskDetailDialog.razor
@@ -36,7 +36,7 @@
 @code {
     [CascadingParameter] IMudDialogInstance MudDialog { get; set; } = default!;
 
-    [Parameter] public PickingListItem Item { get; set; } = new();
+    [Parameter] public PickingListItem Item { get; set; }
 
     public decimal? PulledQuantity { get; set; }
     public decimal? PulledWeight { get; set; }

--- a/Components/Pages/Operations/Pickinglist/PickingListDialog.razor
+++ b/Components/Pages/Operations/Pickinglist/PickingListDialog.razor
@@ -161,7 +161,7 @@
 </MudDialog>
 
 @code {
-    [Parameter] public PickingList Model { get; set; } = new();
+    [Parameter] public PickingList Model { get; set; }
     [Parameter] public bool IsEdit { get; set; }
     [Parameter] public string Title { get; set; } = "";
     [Parameter] public List<Branch> Branches { get; set; } = new();
@@ -219,6 +219,8 @@
         {
             ["Item"] = new PickingListItem
             {
+                ItemId = string.Empty,
+                ItemDescription = string.Empty,
                 LineNumber = (Model.Items.Any() ? Model.Items.Max(i => i.LineNumber) : 0) + 1,
                 Unit = "EA",
                 Status = PickingLineStatus.Pending

--- a/Components/Pages/Operations/Pickinglist/PickingListItemDialog.razor
+++ b/Components/Pages/Operations/Pickinglist/PickingListItemDialog.razor
@@ -72,7 +72,7 @@
 
 @code {
     [Parameter] public string Title { get; set; } = "Line Item";
-    [Parameter] public PickingListItem Item { get; set; } = new();
+    [Parameter] public PickingListItem Item { get; set; }
     [Parameter] public List<Machine> Machines { get; set; } = new();
 
     [CascadingParameter] public IMudDialogInstance Dialog { get; set; } = default!;

--- a/Components/Pages/Operations/Pickinglist/PickingLists.razor
+++ b/Components/Pages/Operations/Pickinglist/PickingLists.razor
@@ -162,6 +162,7 @@
 
         var model = new PickingList
         {
+            SalesOrderNumber = string.Empty,
             Status = PickingListStatus.Pending,
             BranchId = (!isAdmin && userBranchId.HasValue) ? userBranchId.Value : (branches.FirstOrDefault()?.Id ?? 0)
         };

--- a/Components/Pages/Operations/PullingTasks.razor
+++ b/Components/Pages/Operations/PullingTasks.razor
@@ -4,7 +4,7 @@
 @using System.Security.Claims
 @using Microsoft.AspNetCore.Components.Authorization
 @inject PickingListService PickingListService
-@inject TaskAuditEventService AuditService
+@inject ITaskAuditEventService AuditService
 @inject ISnackbar Snackbar
 @inject AuthenticationStateProvider AuthStateProvider
 @inject IDialogService DialogService

--- a/Components/Pages/Operations/WorkOrder/WorkOrderDialog.razor
+++ b/Components/Pages/Operations/WorkOrder/WorkOrderDialog.razor
@@ -8,7 +8,7 @@
 @inject ItemRelationshipService RelService
 @inject PickingListService PlService
 @inject WorkOrderService WorkOrderService
-@inject TaskAuditEventService AuditService
+@inject ITaskAuditEventService AuditService
 
 <MudDialog Title="@Title">
     <DialogContent>
@@ -504,7 +504,7 @@
     private async Task CompleteTaskAsync()
     {
         Model.Status = WorkOrderStatus.Completed;
-        await CreateAuditEventAsync(AuditEventType.End);
+        await CreateAuditEventAsync(AuditEventType.Complete);
         await WorkOrderService.UpdateAsync(Model, (await AuthState).User.Identity?.Name ?? "Unknown");
         MudDialog.Close(DialogResult.Ok(true));
     }

--- a/Components/Pages/Schedule/Dialogs/PullingTaskDetailDialog.razor
+++ b/Components/Pages/Schedule/Dialogs/PullingTaskDetailDialog.razor
@@ -36,7 +36,7 @@
 @code {
     [CascadingParameter] IMudDialogInstance MudDialog { get; set; } = default!;
 
-    [Parameter] public PickingListItem Item { get; set; } = new();
+    [Parameter] public PickingListItem Item { get; set; }
 
     public decimal? PulledQuantity { get; set; }
     public decimal? PulledWeight { get; set; }

--- a/Components/Pages/Schedule/Dialogs/WorkOrderDetailsDialog.razor
+++ b/Components/Pages/Schedule/Dialogs/WorkOrderDetailsDialog.razor
@@ -11,7 +11,7 @@
 @inject IAuthorizationService AuthorizationService
 @inject ISnackbar Snackbar
 @inject IDialogService DialogService
-@inject IAuditEventService AuditEventService
+@inject ITaskAuditEventService AuditEventService
 
 <MudDialog>
     <TitleContent>

--- a/Components/Pages/Schedule/MachineScheduleBase.razor
+++ b/Components/Pages/Schedule/MachineScheduleBase.razor
@@ -195,7 +195,7 @@
             ["IsProcessing"] = isProcessing
         };
 
-        var options = new DialogOptions { MaxWidth = MaxWidth.ExtraLarge, FullWidth = true, DisableBackdropClick = true };
+        var options = new DialogOptions { MaxWidth = MaxWidth.ExtraLarge, FullWidth = true, BackdropClick = false };
         var dialog = await DialogService.ShowAsync<WorkOrderDialog>(isProcessing ? "Process Work Order" : "Edit Work Order", parameters, options);
         var result = await dialog.Result;
 

--- a/Data/Pickinglist.cs
+++ b/Data/Pickinglist.cs
@@ -9,7 +9,8 @@ namespace CMetalsWS.Data
     {
         public int Id { get; set; }
         [Required, MaxLength(64)]
-        public string SalesOrderNumber { get; set; } = default!;
+        public required string SalesOrderNumber { get; set; }
+        public DateTime? ShipDate { get; set; }
         [Required]
         public int BranchId { get; set; }
         public virtual Branch Branch { get; set; } = null!;
@@ -34,10 +35,10 @@ namespace CMetalsWS.Data
         public int LineNumber { get; set; }
 
         [Required, MaxLength(64)]
-        public string ItemId { get; set; } = default!;
+        public required string ItemId { get; set; }
 
         [Required, MaxLength(256)]
-        public string ItemDescription { get; set; } = default!;
+        public required string ItemDescription { get; set; }
 
         [Precision(18, 3)]
         public decimal Quantity { get; set; }

--- a/Migrations/20250905005729_AddShipDateToPickingList.Designer.cs
+++ b/Migrations/20250905005729_AddShipDateToPickingList.Designer.cs
@@ -4,6 +4,7 @@ using CMetalsWS.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CMetalsWS.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250905005729_AddShipDateToPickingList")]
+    partial class AddShipDateToPickingList
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20250905005729_AddShipDateToPickingList.cs
+++ b/Migrations/20250905005729_AddShipDateToPickingList.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CMetalsWS.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddShipDateToPickingList : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "ShipDate",
+                table: "PickingLists",
+                type: "datetime2",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ShipDate",
+                table: "PickingLists");
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -87,7 +87,7 @@ builder.Services.AddScoped<DashboardService>();
 builder.Services.AddScoped<LoadService>();
 builder.Services.AddScoped<WorkOrderService>();
 builder.Services.AddScoped<CustomerService>();
-builder.Services.AddScoped<TaskAuditEventService>();
+builder.Services.AddScoped<ITaskAuditEventService, TaskAuditEventService>();
 builder.Services.AddSignalR();
 
 var app = builder.Build();

--- a/Services/ITaskAuditEventService.cs
+++ b/Services/ITaskAuditEventService.cs
@@ -1,0 +1,12 @@
+using CMetalsWS.Data;
+using System.Threading.Tasks;
+
+namespace CMetalsWS.Services
+{
+    public interface ITaskAuditEventService
+    {
+        Task CreateAuditEventAsync(int taskId, TaskType taskType, AuditEventType eventType, string userId, string? notes = null);
+        Task<AuditEventType?> GetLastEventTypeForTaskAsync(int taskId, TaskType taskType);
+        Task<Dictionary<int, AuditEventType>> GetLastEventTypesForTasksAsync(List<int> taskIds, TaskType taskType);
+    }
+}

--- a/Services/TaskAuditEventService.cs
+++ b/Services/TaskAuditEventService.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace CMetalsWS.Services
 {
-    public class TaskAuditEventService
+    public class TaskAuditEventService : ITaskAuditEventService
     {
         private readonly IDbContextFactory<ApplicationDbContext> _contextFactory;
 


### PR DESCRIPTION
This change fixes several build errors and sets up the environment for .NET 9 and SQL Server.

The main changes are:
- Updated the project to be compatible with .NET 9.
- Fixed several build errors related to nullability and required properties.
- Added a `ShipDate` property to the `PickingList` class and created a database migration.
- Corrected an enum usage from `AuditEventType.End` to `AuditEventType.Complete`.
- Fixed a deprecated MudBlazor property.
- Introduced an interface for the `TaskAuditEventService`.
- Removed an unsolicited `dotnet-install.sh` script.