### PR TITLE
Fix chat auth and DbContext threading issue

### DIFF
--- a/Components/Layout/MainLayout.razor
+++ b/Components/Layout/MainLayout.razor
@@ -39,7 +39,11 @@
     </MudMainContent>
 </MudLayout>
 
-<Chat />
+<AuthorizeView>
+    <Authorized>
+        <Chat />
+    </Authorized>
+</AuthorizeView>
 
 <!-- Blazor error UI -->
 <div id="blazor-error-ui" data-nosnippet>

--- a/Services/IChatService.cs
+++ b/Services/IChatService.cs
@@ -7,7 +7,7 @@ namespace CMetalsWS.Services
     public interface IChatService
     {
         Task<List<ApplicationUser>> GetUsersAsync();
-        Task<ApplicationUser> GetUserDetailsAsync(string userId);
+        Task<ApplicationUser?> GetUserDetailsAsync(string userId);
         Task<List<ChatMessage>> GetConversationAsync(string currentUserId, string contactId);
         Task SaveMessageAsync(ChatMessage message);
         Task<List<ChatGroup>> GetUserGroupsAsync(string userId);


### PR DESCRIPTION
This commit addresses two main issues:
1. A `System.InvalidOperationException` caused by concurrent `DbContext` usage.
2. A requirement to restrict the chat feature to authenticated users.

The `DbContext` threading issue was resolved by refactoring the `ChatService` to use `IDbContextFactory`, ensuring that a new `DbContext` instance is created for each operation.

The chat feature is now restricted to authenticated users by wrapping the `Chat` component in an `AuthorizeView` in the main layout.

This commit also includes previous changes to remove unused permissions and fix build errors.