### PR TITLE
fix: Refactor nested AuthorizeView to fix RZ9999 error

### DIFF
--- a/Components/Pages/Admin/Branches.razor
+++ b/Components/Pages/Admin/Branches.razor
@@ -7,6 +7,7 @@
 
 @inject BranchService BranchService
 @inject IDialogService DialogService
+@inject IAuthorizationService AuthorizationService
 
 <MudPaper Class="p-4">
     <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
@@ -17,7 +18,7 @@
             </Authorized>
         </AuthorizeView>
     </MudStack>
-    <MudTable Items="branches" Hover="true">
+    <MudTable Items="branches" Hover="true" Context="branch">
         <HeaderContent>
             <MudTh>Code</MudTh>
             <MudTh>Name</MudTh>
@@ -25,20 +26,18 @@
             <MudTh>Actions</MudTh>
         </HeaderContent>
         <RowTemplate>
-            <MudTd DataLabel="Code">@context.Code</MudTd>
-            <MudTd DataLabel="Name">@context.Name</MudTd>
-            <MudTd DataLabel="City">@context.City</MudTd>
+            <MudTd DataLabel="Code">@branch.Code</MudTd>
+            <MudTd DataLabel="Name">@branch.Name</MudTd>
+            <MudTd DataLabel="City">@branch.City</MudTd>
             <MudTd DataLabel="Actions">
-                <AuthorizeView Policy="@Permissions.Branches.Edit">
-                    <Authorized>
-                        <MudIconButton Color="Color.Info" Icon="@Icons.Material.Filled.Edit" OnClick="@(() => EditBranch(context))"></MudIconButton>
-                    </Authorized>
-                </AuthorizeView>
-                <AuthorizeView Policy="@Permissions.Branches.Delete">
-                    <Authorized>
-                        <MudIconButton Color="Color.Error" Icon="@Icons.Material.Filled.Delete" OnClick="@(() => DeleteBranch(context))"></MudIconButton>
-                    </Authorized>
-                </AuthorizeView>
+                @if (_canEdit)
+                {
+                    <MudIconButton Color="Color.Info" Icon="@Icons.Material.Filled.Edit" OnClick="@(() => EditBranch(branch))"></MudIconButton>
+                }
+                @if (_canDelete)
+                {
+                    <MudIconButton Color="Color.Error" Icon="@Icons.Material.Filled.Delete" OnClick="@(() => DeleteBranch(branch))"></MudIconButton>
+                }
             </MudTd>
         </RowTemplate>
     </MudTable>
@@ -46,9 +45,17 @@
 
 @code {
     private List<Branch> branches = new();
+    private bool _canEdit;
+    private bool _canDelete;
+
+    [CascadingParameter]
+    private Task<AuthenticationState> AuthState { get; set; } = default!;
 
     protected override async Task OnInitializedAsync()
     {
+        var user = (await AuthState).User;
+        _canEdit = (await AuthorizationService.AuthorizeAsync(user, Permissions.Branches.Edit)).Succeeded;
+        _canDelete = (await AuthorizationService.AuthorizeAsync(user, Permissions.Branches.Delete)).Succeeded;
         branches = await BranchService.GetBranchesAsync();
     }
 

--- a/Components/Pages/Admin/ChatGroups.razor
+++ b/Components/Pages/Admin/ChatGroups.razor
@@ -11,6 +11,7 @@
 @inject UserService UserService
 @inject IDialogService DialogService
 @inject ISnackbar Snackbar
+@inject IAuthorizationService AuthorizationService
 
 <MudPaper Class="p-4">
     <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
@@ -27,28 +28,27 @@
         </AuthorizeView>
     </MudStack>
 
-    <MudTable Items="_groups" Hover="true" Dense="true">
+    <MudTable Items="_groups" Hover="true" Dense="true" Context="group">
         <HeaderContent>
             <MudTh>Name</MudTh>
             <MudTh>Branch</MudTh>
             <MudTh>Actions</MudTh>
         </HeaderContent>
         <RowTemplate>
-            <MudTd DataLabel="Name">@context.Name</MudTd>
-            <MudTd DataLabel="Branch">@context.Branch?.Name</MudTd>
+            <MudTd DataLabel="Name">@group.Name</MudTd>
+            <MudTd DataLabel="Branch">@group.Branch?.Name</MudTd>
             <MudTd DataLabel="Actions">
-                <AuthorizeView Policy="@Permissions.Users.Edit">
-                    <Authorized>
-                        <MudIconButton Color="Color.Info"
-                                       Icon="@Icons.Material.Filled.Edit"
-                                       title="Edit"
-                                       OnClick="@(() => EditGroup(context))" />
-                        <MudIconButton Color="Color.Error"
-                                       Icon="@Icons.Material.Filled.Delete"
-                                       title="Delete"
-                                       OnClick="@(() => DeleteGroup(context))" />
-                    </Authorized>
-                </AuthorizeView>
+                @if (_canEdit)
+                {
+                    <MudIconButton Color="Color.Info"
+                                   Icon="@Icons.Material.Filled.Edit"
+                                   title="Edit"
+                                   OnClick="@(() => EditGroup(group))" />
+                    <MudIconButton Color="Color.Error"
+                                   Icon="@Icons.Material.Filled.Delete"
+                                   title="Delete"
+                                   OnClick="@(() => DeleteGroup(group))" />
+                }
             </MudTd>
         </RowTemplate>
     </MudTable>
@@ -56,9 +56,15 @@
 
 @code {
     private List<ChatGroup> _groups = new();
+    private bool _canEdit;
+
+    [CascadingParameter]
+    private Task<AuthenticationState> AuthState { get; set; } = default!;
 
     protected override async Task OnInitializedAsync()
     {
+        var user = (await AuthState).User;
+        _canEdit = (await AuthorizationService.AuthorizeAsync(user, Permissions.Users.Edit)).Succeeded;
         await LoadGroupsAsync();
     }
 

--- a/Components/Pages/Admin/Machines.razor
+++ b/Components/Pages/Admin/Machines.razor
@@ -9,6 +9,7 @@
 @inject BranchService BranchService
 @inject IDialogService DialogService
 @inject ISnackbar Snackbar
+@inject IAuthorizationService AuthorizationService
 
 <MudPaper Class="p-4">
     <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
@@ -22,7 +23,7 @@
         </AuthorizeView>
     </MudStack>
 
-    <MudTable Items="items" Hover="true" Dense="true">
+    <MudTable Items="items" Hover="true" Dense="true" Context="machine">
         <HeaderContent>
             <MudTh>Code</MudTh>
             <MudTh>Name</MudTh>
@@ -31,27 +32,25 @@
             <MudTh>Actions</MudTh>
         </HeaderContent>
         <RowTemplate>
-            <MudTd DataLabel="Code">@context.Code</MudTd>
-            <MudTd DataLabel="Name">@context.Name</MudTd>
-            <MudTd DataLabel="Category">@context.Category</MudTd>
-            <MudTd DataLabel="Branch">@context.Branch?.Name</MudTd>
+            <MudTd DataLabel="Code">@machine.Code</MudTd>
+            <MudTd DataLabel="Name">@machine.Name</MudTd>
+            <MudTd DataLabel="Category">@machine.Category</MudTd>
+            <MudTd DataLabel="Branch">@machine.Branch?.Name</MudTd>
             <MudTd DataLabel="Actions">
-                <AuthorizeView Policy="@Permissions.Machines.Edit">
-                    <Authorized Context="authEdit">
-                        <MudIconButton Color="Color.Info"
-                                       Icon="@Icons.Material.Filled.Edit"
-                                       title="Edit"
-                                       OnClick="@(async () => await EditMachine(context))" />
-                    </Authorized>
-                </AuthorizeView>
-                <AuthorizeView Policy="@Permissions.Machines.Delete">
-                    <Authorized Context="authDelete">
-                        <MudIconButton Color="Color.Error"
-                                       Icon="@Icons.Material.Filled.Delete"
-                                       title="Delete"
-                                       OnClick="@(async () => await DeleteMachine(context))" />
-                    </Authorized>
-                </AuthorizeView>
+                @if (_canEdit)
+                {
+                    <MudIconButton Color="Color.Info"
+                                   Icon="@Icons.Material.Filled.Edit"
+                                   title="Edit"
+                                   OnClick="@(async () => await EditMachine(machine))" />
+                }
+                @if (_canDelete)
+                {
+                    <MudIconButton Color="Color.Error"
+                                   Icon="@Icons.Material.Filled.Delete"
+                                   title="Delete"
+                                   OnClick="@(async () => await DeleteMachine(machine))" />
+                }
             </MudTd>
         </RowTemplate>
     </MudTable>
@@ -59,9 +58,17 @@
 
 @code {
     private List<Machine> items = new();
+    private bool _canEdit;
+    private bool _canDelete;
+
+    [CascadingParameter]
+    private Task<AuthenticationState> AuthState { get; set; } = default!;
 
     protected override async Task OnInitializedAsync()
     {
+        var user = (await AuthState).User;
+        _canEdit = (await AuthorizationService.AuthorizeAsync(user, Permissions.Machines.Edit)).Succeeded;
+        _canDelete = (await AuthorizationService.AuthorizeAsync(user, Permissions.Machines.Delete)).Succeeded;
         await LoadAsync();
     }
 

--- a/Components/Pages/Admin/Roles.razor
+++ b/Components/Pages/Admin/Roles.razor
@@ -8,6 +8,7 @@
 @inject RoleService RoleService
 @inject IDialogService DialogService
 @inject ISnackbar Snackbar
+@inject IAuthorizationService AuthorizationService
 
 <MudPaper Class="p-4">
     <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
@@ -18,26 +19,24 @@
             </Authorized>
         </AuthorizeView>
     </MudStack>
-    <MudTable Items="roles" Hover="true">
+    <MudTable Items="roles" Hover="true" Context="role">
         <HeaderContent>
             <MudTh>Name</MudTh>
             <MudTh>Description</MudTh>
             <MudTh>Actions</MudTh>
         </HeaderContent>
         <RowTemplate>
-            <MudTd DataLabel="Name">@context.Name</MudTd>
-            <MudTd DataLabel="Description">@context.Description</MudTd>
+            <MudTd DataLabel="Name">@role.Name</MudTd>
+            <MudTd DataLabel="Description">@role.Description</MudTd>
             <MudTd DataLabel="Actions">
-                <AuthorizeView Policy="@Permissions.Roles.Edit">
-                    <Authorized>
-                        <MudIconButton Color="Color.Info" Icon="@Icons.Material.Filled.Edit" OnClick="@(() => EditRole(context))"></MudIconButton>
-                    </Authorized>
-                </AuthorizeView>
-                <AuthorizeView Policy="@Permissions.Roles.Delete">
-                    <Authorized>
-                        <MudIconButton Color="Color.Error" Icon="@Icons.Material.Filled.Delete" OnClick="@(() => DeleteRole(context))"></MudIconButton>
-                    </Authorized>
-                </AuthorizeView>
+                @if (_canEdit)
+                {
+                    <MudIconButton Color="Color.Info" Icon="@Icons.Material.Filled.Edit" OnClick="@(() => EditRole(role))"></MudIconButton>
+                }
+                @if (_canDelete)
+                {
+                    <MudIconButton Color="Color.Error" Icon="@Icons.Material.Filled.Delete" OnClick="@(() => DeleteRole(role))"></MudIconButton>
+                }
             </MudTd>
         </RowTemplate>
     </MudTable>
@@ -45,9 +44,17 @@
 
 @code {
     private List<ApplicationRole> roles = new();
+    private bool _canEdit;
+    private bool _canDelete;
+
+    [CascadingParameter]
+    private Task<AuthenticationState> AuthState { get; set; } = default!;
 
     protected override async Task OnInitializedAsync()
     {
+        var user = (await AuthState).User;
+        _canEdit = (await AuthorizationService.AuthorizeAsync(user, Permissions.Roles.Edit)).Succeeded;
+        _canDelete = (await AuthorizationService.AuthorizeAsync(user, Permissions.Roles.Delete)).Succeeded;
         await LoadRoles();
     }
 

--- a/Components/Pages/Admin/Trucks.razor
+++ b/Components/Pages/Admin/Trucks.razor
@@ -10,6 +10,7 @@
 @inject UserService UserService
 @inject IDialogService DialogService
 @inject ISnackbar Snackbar
+@inject IAuthorizationService AuthorizationService
 
 <MudPaper Class="p-4">
     <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
@@ -23,7 +24,7 @@
         </AuthorizeView>
     </MudStack>
 
-    <MudTable Items="items" Hover="true" Dense="true">
+    <MudTable Items="items" Hover="true" Dense="true" Context="truck">
         <HeaderContent>
             <MudTh>Name</MudTh>
             <MudTh>Identifier</MudTh>
@@ -35,32 +36,30 @@
             <MudTh>Actions</MudTh>
         </HeaderContent>
         <RowTemplate>
-            <MudTd DataLabel="Name">@context.Name</MudTd>
-            <MudTd DataLabel="Identifier">@context.Identifier</MudTd>
-            <MudTd DataLabel="Branch">@context.Branch?.Name</MudTd>
-            <MudTd DataLabel="Driver">@($"{context.Driver?.FirstName} {context.Driver?.LastName}".Trim())</MudTd>
-            <MudTd DataLabel="Capacity Weight" Class="text-right">@context.CapacityWeight.ToString("N2")</MudTd>
-            <MudTd DataLabel="Capacity Volume" Class="text-right">@context.CapacityVolume.ToString("N2")</MudTd>
+            <MudTd DataLabel="Name">@truck.Name</MudTd>
+            <MudTd DataLabel="Identifier">@truck.Identifier</MudTd>
+            <MudTd DataLabel="Branch">@truck.Branch?.Name</MudTd>
+            <MudTd DataLabel="Driver">@($"{truck.Driver?.FirstName} {truck.Driver?.LastName}".Trim())</MudTd>
+            <MudTd DataLabel="Capacity Weight" Class="text-right">@truck.CapacityWeight.ToString("N2")</MudTd>
+            <MudTd DataLabel="Capacity Volume" Class="text-right">@truck.CapacityVolume.ToString("N2")</MudTd>
             <MudTd DataLabel="Active">
-                <MudIcon Icon="@(context.IsActive? Icons.Material.Filled.CheckCircle : Icons.Material.Outlined.RadioButtonUnchecked)" Color="@(context.IsActive? Color.Success: Color.Default)" />
+                <MudIcon Icon="@(truck.IsActive? Icons.Material.Filled.CheckCircle : Icons.Material.Outlined.RadioButtonUnchecked)" Color="@(truck.IsActive? Color.Success: Color.Default)" />
             </MudTd>
             <MudTd DataLabel="Actions">
-                <AuthorizeView Policy="@Permissions.Trucks.Edit">
-                    <Authorized Context="authEdit">
-                        <MudIconButton Color="Color.Info"
-                                       Icon="@Icons.Material.Filled.Edit"
-                                       title="Edit"
-                                       OnClick="@(async () => await EditTruck(context))" />
-                    </Authorized>
-                </AuthorizeView>
-                <AuthorizeView Policy="@Permissions.Trucks.Delete">
-                    <Authorized Context="authDelete">
-                        <MudIconButton Color="Color.Error"
-                                       Icon="@Icons.Material.Filled.Delete"
-                                       title="Delete"
-                                       OnClick="@(async () => await DeleteTruck(context))" />
-                    </Authorized>
-                </AuthorizeView>
+                @if (_canEdit)
+                {
+                    <MudIconButton Color="Color.Info"
+                                   Icon="@Icons.Material.Filled.Edit"
+                                   title="Edit"
+                                   OnClick="@(async () => await EditTruck(truck))" />
+                }
+                @if (_canDelete)
+                {
+                    <MudIconButton Color="Color.Error"
+                                   Icon="@Icons.Material.Filled.Delete"
+                                   title="Delete"
+                                   OnClick="@(async () => await DeleteTruck(truck))" />
+                }
             </MudTd>
         </RowTemplate>
     </MudTable>
@@ -69,9 +68,17 @@
 @code {
     private List<Truck> items = new();
     private List<ApplicationUser> drivers = new();
+    private bool _canEdit;
+    private bool _canDelete;
+
+    [CascadingParameter]
+    private Task<AuthenticationState> AuthState { get; set; } = default!;
 
     protected override async Task OnInitializedAsync()
     {
+        var user = (await AuthState).User;
+        _canEdit = (await AuthorizationService.AuthorizeAsync(user, Permissions.Trucks.Edit)).Succeeded;
+        _canDelete = (await AuthorizationService.AuthorizeAsync(user, Permissions.Trucks.Delete)).Succeeded;
         await LoadAsync();
     }
 

--- a/Components/Pages/Admin/Users.razor
+++ b/Components/Pages/Admin/Users.razor
@@ -9,6 +9,7 @@
 @inject BranchService BranchService
 @inject RoleService RoleService
 @inject IDialogService DialogService
+@inject IAuthorizationService AuthorizationService
 
 <MudPaper Class="p-4">
     <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
@@ -26,7 +27,7 @@
         </AuthorizeView>
     </MudStack>
 
-    <MudTable Items="users" Hover="true" Dense="true">
+    <MudTable Items="users" Hover="true" Dense="true" Context="user">
         <HeaderContent>
             <MudTh>User Name</MudTh>
             <MudTh>Email</MudTh>
@@ -35,27 +36,25 @@
             <MudTh>Actions</MudTh>
         </HeaderContent>
         <RowTemplate>
-            <MudTd DataLabel="User Name">@context.UserName</MudTd>
-            <MudTd DataLabel="Email">@context.Email</MudTd>
-            <MudTd DataLabel="Branch">@context.Branch?.Name</MudTd>
-            <MudTd DataLabel="Roles">@string.Join(", ", roleDict.TryGetValue(context.Id, out var r) ? r : new List<string>())</MudTd>
+            <MudTd DataLabel="User Name">@user.UserName</MudTd>
+            <MudTd DataLabel="Email">@user.Email</MudTd>
+            <MudTd DataLabel="Branch">@user.Branch?.Name</MudTd>
+            <MudTd DataLabel="Roles">@string.Join(", ", roleDict.TryGetValue(user.Id, out var r) ? r : new List<string>())</MudTd>
             <MudTd DataLabel="Actions">
-                <AuthorizeView Policy="@Permissions.Users.Edit">
-                    <Authorized Context="authEdit">
-                        <MudIconButton Color="Color.Info"
-                                       Icon="@Icons.Material.Filled.Edit"
-                                       title="Edit"
-                                       OnClick="@(() => EditUser(context))" />
-                    </Authorized>
-                </AuthorizeView>
-                <AuthorizeView Policy="@Permissions.Users.Delete">
-                    <Authorized Context="authDelete">
-                        <MudIconButton Color="Color.Error"
-                                       Icon="@Icons.Material.Filled.Delete"
-                                       title="Delete"
-                                       OnClick="@(() => DeleteUser(context))" />
-                    </Authorized>
-                </AuthorizeView>
+                @if (_canEdit)
+                {
+                    <MudIconButton Color="Color.Info"
+                                   Icon="@Icons.Material.Filled.Edit"
+                                   title="Edit"
+                                   OnClick="@(() => EditUser(user))" />
+                }
+                @if (_canDelete)
+                {
+                    <MudIconButton Color="Color.Error"
+                                   Icon="@Icons.Material.Filled.Delete"
+                                   title="Delete"
+                                   OnClick="@(() => DeleteUser(user))" />
+                }
             </MudTd>
         </RowTemplate>
     </MudTable>
@@ -64,9 +63,17 @@
 @code {
     private List<ApplicationUser> users = new();
     private readonly Dictionary<string, List<string>> roleDict = new();
+    private bool _canEdit;
+    private bool _canDelete;
+
+    [CascadingParameter]
+    private Task<AuthenticationState> AuthState { get; set; } = default!;
 
     protected override async Task OnInitializedAsync()
     {
+        var authUser = (await AuthState).User;
+        _canEdit = (await AuthorizationService.AuthorizeAsync(authUser, Permissions.Users.Edit)).Succeeded;
+        _canDelete = (await AuthorizationService.AuthorizeAsync(authUser, Permissions.Users.Delete)).Succeeded;
         await LoadUsersAsync();
     }
 

--- a/Components/Pages/Counter.razor
+++ b/Components/Pages/Counter.razor
@@ -1,4 +1,6 @@
 ﻿@page "/counter"
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize]
 
 <PageTitle>Counter</PageTitle>
 

--- a/Components/Pages/Operations/Inventory/Inventory.razor
+++ b/Components/Pages/Operations/Inventory/Inventory.razor
@@ -5,7 +5,9 @@
 @using Microsoft.AspNetCore.Components.Forms
 @using CMetalsWS.Data
 @using CMetalsWS.Services
+@using CMetalsWS.Security
 @using MiniExcelLibs.Attributes
+@attribute [Authorize(Policy = Permissions.WorkOrders.Add)]
 @inject InventoryService InventoryService
 @inject AuthenticationStateProvider AuthStateProvider
 @inject UserManager<ApplicationUser> UserManager
@@ -29,11 +31,13 @@
                            style="position:absolute; inset:0; opacity:0; cursor:pointer;" />
             </div>
 
-            <MudButton Variant="Variant.Outlined"
-                       Disabled="@(!_preview.Any())"
-                       OnClick="SaveAsync">
-                Save to Database
-            </MudButton>
+            <AuthorizeView>
+                <MudButton Variant="Variant.Outlined"
+                           Disabled="@(!_preview.Any())"
+                           OnClick="SaveAsync">
+                    Save to Database
+                </MudButton>
+            </AuthorizeView>
 
             <MudChip T="string" Variant="Variant.Outlined" class="ml-4">
                 Branch: @_branchIdDisplay

--- a/Components/Pages/Operations/ItemRelations.razor
+++ b/Components/Pages/Operations/ItemRelations.razor
@@ -1,6 +1,8 @@
 ﻿@page "/operations/item-relations"
 @using CMetalsWS.Data
 @using CMetalsWS.Services
+@using CMetalsWS.Security
+@attribute [Authorize(Policy = Permissions.WorkOrders.Edit)]
 @inject ItemRelationshipService RelService
 @inject ISnackbar Snackbar
 

--- a/Components/Pages/Operations/Loads/LoadPlanning.razor
+++ b/Components/Pages/Operations/Loads/LoadPlanning.razor
@@ -1,6 +1,8 @@
 @page "/load-planning"
 @using CMetalsWS.Data
+@using CMetalsWS.Security
 @using MudBlazor
+@attribute [Authorize(Policy = Permissions.PickingLists.ManageLoads)]
 
 <MudPaper Class="pa-4">
     <MudText Typo="Typo.h5">Load Planning</MudText>

--- a/Components/Pages/Operations/Loads/LoadSchedule.razor
+++ b/Components/Pages/Operations/Loads/LoadSchedule.razor
@@ -1,8 +1,10 @@
 ﻿@page "/schedule/loads"
 @using CMetalsWS.Data
 @using CMetalsWS.Services
+@using CMetalsWS.Security
 @using MudBlazor
 @using Microsoft.AspNetCore.Components.Authorization
+@attribute [Authorize(Policy = Permissions.PickingLists.ManageLoads)]
 
 @inject LoadService LoadService
 @inject TruckService TruckService
@@ -28,12 +30,16 @@
                 <MudTd>@($"{context.ShippingDate:yyyy-MM-dd}")</MudTd>
                 <MudTd>@context.Status</MudTd>
                 <MudTd>
-                    <MudButton Variant="Variant.Text" OnClick="@(async () => await EditLoad(context))">Edit</MudButton>
+                    <AuthorizeView>
+                        <MudButton Variant="Variant.Text" OnClick="@(async () => await EditLoad(context))">Edit</MudButton>
+                    </AuthorizeView>
                 </MudTd>
             </RowTemplate>
         </MudTable>
 
-        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="CreateLoad">New Load</MudButton>
+        <AuthorizeView>
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="CreateLoad">New Load</MudButton>
+        </AuthorizeView>
     </MudStack>
 
 </MudPaper>

--- a/Components/Pages/Operations/Loads/TruckRoutes.razor
+++ b/Components/Pages/Operations/Loads/TruckRoutes.razor
@@ -1,6 +1,8 @@
 ﻿@page "/routes"
 @using CMetalsWS.Data
 @using CMetalsWS.Services
+@using CMetalsWS.Security
+@attribute [Authorize(Policy = Permissions.PickingLists.View)]
 @inject LoadService LoadService
 @inject RouteService RouteService
 

--- a/Components/Pages/Operations/Pickinglist/PickingLists.razor
+++ b/Components/Pages/Operations/Pickinglist/PickingLists.razor
@@ -16,6 +16,7 @@
 @inject ISnackbar Snackbar
 @inject AuthenticationStateProvider AuthStateProvider
 @inject UserManager<ApplicationUser> UserManager
+@inject IAuthorizationService AuthorizationService
 
 <MudPaper Class="p-4">
     <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
@@ -40,7 +41,7 @@
         </AuthorizeView>
     </MudStack>
 
-    <MudTable Items="lists" Hover="true" Dense="true">
+    <MudTable Items="lists" Hover="true" Dense="true" Context="pickingList">
         <HeaderContent>
             <MudTh>SO #</MudTh>
             <MudTh>Customer</MudTh>
@@ -54,26 +55,24 @@
                 <MudButton Variant="Variant.Text"
                            Color="Color.Primary"
                            Class="px-0"
-                           OnClick="@(async () => await View(context))"
+                           OnClick="@(async () => await View(pickingList))"
                            title="View Picking List">
-                    @context.SalesOrderNumber
+                    @pickingList.SalesOrderNumber
                 </MudButton>
             </MudTd>
-            <MudTd DataLabel="Customer">@context.Customer?.CustomerName</MudTd>
-            <MudTd DataLabel="Loc">@context.Customer?.LocationCode</MudTd>
-            <MudTd DataLabel="Status">@context.Status</MudTd>
-            <MudTd DataLabel="Total Wt" Class="text-right">@context.TotalWeight.ToString("N3")</MudTd>
+            <MudTd DataLabel="Customer">@pickingList.Customer?.CustomerName</MudTd>
+            <MudTd DataLabel="Loc">@pickingList.Customer?.LocationCode</MudTd>
+            <MudTd DataLabel="Status">@pickingList.Status</MudTd>
+            <MudTd DataLabel="Total Wt" Class="text-right">@pickingList.TotalWeight.ToString("N3")</MudTd>
             <MudTd DataLabel="Actions">
-                <AuthorizeView Policy="@Permissions.PickingLists.Edit">
-                    <Authorized Context="authEdit">
-                        <MudIconButton Color="Color.Info" Icon="@Icons.Material.Filled.Edit" title="Edit" OnClick="@(async () => await Edit(context))" />
-                    </Authorized>
-                </AuthorizeView>
-                <AuthorizeView Policy="@Permissions.PickingLists.Delete">
-                    <Authorized Context="authDelete">
-                        <MudIconButton Color="Color.Error" Icon="@Icons.Material.Filled.Delete" title="Delete" OnClick="@(async () => await Delete(context))" />
-                    </Authorized>
-                </AuthorizeView>
+                @if (_canEdit)
+                {
+                    <MudIconButton Color="Color.Info" Icon="@Icons.Material.Filled.Edit" title="Edit" OnClick="@(async () => await Edit(pickingList))" />
+                }
+                @if (_canDelete)
+                {
+                    <MudIconButton Color="Color.Error" Icon="@Icons.Material.Filled.Delete" title="Delete" OnClick="@(async () => await Delete(pickingList))" />
+                }
             </MudTd>
         </RowTemplate>
         <NoRecordsContent>
@@ -87,9 +86,15 @@
     private bool isAdmin;
     private int? userBranchId;
     private Branch? userBranch;
+    private bool _canEdit;
+    private bool _canDelete;
 
     protected override async Task OnInitializedAsync()
     {
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        var user = authState.User;
+        _canEdit = (await AuthorizationService.AuthorizeAsync(user, Permissions.PickingLists.Edit)).Succeeded;
+        _canDelete = (await AuthorizationService.AuthorizeAsync(user, Permissions.PickingLists.Delete)).Succeeded;
         await LoadUserContextAsync();
         await LoadAsync();
     }

--- a/Components/Pages/Operations/Pickinglist/Upload.razor
+++ b/Components/Pages/Operations/Pickinglist/Upload.razor
@@ -7,6 +7,8 @@
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.Components.Forms
 @using MudBlazor
+@using CMetalsWS.Security
+@attribute [Authorize(Policy = Permissions.PickingLists.Add)]
 @inject BranchService BranchService
 @inject IPdfParsingService PdfParsingService
 @inject IPickingListImportService ImportService

--- a/Components/Pages/Operations/PullingTasks.razor
+++ b/Components/Pages/Operations/PullingTasks.razor
@@ -2,7 +2,9 @@
 @using CMetalsWS.Data
 @using CMetalsWS.Services
 @using System.Security.Claims
+@using CMetalsWS.Security
 @using Microsoft.AspNetCore.Components.Authorization
+@attribute [Authorize(Policy = Permissions.PickingLists.Assign)]
 @inject PickingListService PickingListService
 @inject ITaskAuditEventService AuditService
 @inject ISnackbar Snackbar

--- a/Components/Pages/Operations/WorkOrder/WorkOrders.razor
+++ b/Components/Pages/Operations/WorkOrder/WorkOrders.razor
@@ -14,6 +14,7 @@
 @inject IDialogService DialogService
 @inject ISnackbar Snackbar
 @inject NavigationManager Navigation
+@inject IAuthorizationService AuthorizationService
 @implements IAsyncDisposable
 
 <MudPaper Class="pa-4">
@@ -29,7 +30,7 @@
         <MudButton Variant="Variant.Outlined" OnClick="LoadAsync">Refresh</MudButton>
     </MudStack>
 
-    <MudTable Items="@FilteredWorkOrders" Hover="true" Dense="true" Class="mt-4">
+    <MudTable Items="@FilteredWorkOrders" Hover="true" Dense="true" Class="mt-4" Context="workOrder">
         <HeaderContent>
             <MudTh>WO #</MudTh>
             <MudTh>Branch</MudTh>
@@ -43,24 +44,26 @@
             <MudTh></MudTh>
         </HeaderContent>
         <RowTemplate>
-            <MudTd>@context.WorkOrderNumber</MudTd>
-            <MudTd>@context.Branch?.Code</MudTd>
-            <MudTd>@context.MachineCategory</MudTd>
-            <MudTd>@context.Machine?.Name</MudTd>
-            <MudTd>@context.TagNumber</MudTd>
-            <MudTd>@context.DueDate.ToString("yyyy-MM-dd")</MudTd>
-            <MudTd>@context.Status</MudTd>
-            <MudTd>@(context.ScheduledStartDate.ToString("yyyy-MM-dd HH:mm"))</MudTd>
-            <MudTd>@(context.ScheduledEndDate.ToString("yyyy-MM-dd HH:mm"))</MudTd>
+            <MudTd>@workOrder.WorkOrderNumber</MudTd>
+            <MudTd>@workOrder.Branch?.Code</MudTd>
+            <MudTd>@workOrder.MachineCategory</MudTd>
+            <MudTd>@workOrder.Machine?.Name</MudTd>
+            <MudTd>@workOrder.TagNumber</MudTd>
+            <MudTd>@workOrder.DueDate.ToString("yyyy-MM-dd")</MudTd>
+            <MudTd>@workOrder.Status</MudTd>
+            <MudTd>@(workOrder.ScheduledStartDate.ToString("yyyy-MM-dd HH:mm"))</MudTd>
+            <MudTd>@(workOrder.ScheduledEndDate.ToString("yyyy-MM-dd HH:mm"))</MudTd>
             <MudTd>
                 <MudMenu Icon="@Icons.Material.Filled.MoreVert" Dense="true">
-                    <MudMenuItem OnClick="@(() => ViewWorkOrderAsync(context))">Details</MudMenuItem>
-                    <AuthorizeView Policy="@Permissions.WorkOrders.Edit" Context="auth">
-                        <MudMenuItem OnClick="@(() => EditWorkOrderAsync(context))">Edit</MudMenuItem>
-                    </AuthorizeView>
-                    <AuthorizeView Policy="@Permissions.WorkOrders.Process" Context="auth">
-                        <MudMenuItem OnClick="@(() => ProcessWorkOrderAsync(context))">Process</MudMenuItem>
-                    </AuthorizeView>
+                    <MudMenuItem OnClick="@(() => ViewWorkOrderAsync(workOrder))">Details</MudMenuItem>
+                    @if (_canEdit)
+                    {
+                        <MudMenuItem OnClick="@(() => EditWorkOrderAsync(workOrder))">Edit</MudMenuItem>
+                    }
+                    @if (_canProcess)
+                    {
+                        <MudMenuItem OnClick="@(() => ProcessWorkOrderAsync(workOrder))">Process</MudMenuItem>
+                    }
                 </MudMenu>
             </MudTd>
         </RowTemplate>
@@ -74,6 +77,8 @@
     private List<Branch> _branches = new();
     private int? _userBranchId;
     private HubConnection? _hubConnection;
+    private bool _canEdit;
+    private bool _canProcess;
 
     private List<WorkOrder> FilteredWorkOrders =>
         string.IsNullOrWhiteSpace(_searchString)
@@ -88,6 +93,9 @@
         var auth = await AuthStateProvider.GetAuthenticationStateAsync();
         var user = await UserManager.GetUserAsync(auth.User);
         _userBranchId = user?.BranchId;
+
+        _canEdit = (await AuthorizationService.AuthorizeAsync(auth.User, Permissions.WorkOrders.Edit)).Succeeded;
+        _canProcess = (await AuthorizationService.AuthorizeAsync(auth.User, Permissions.WorkOrders.Process)).Succeeded;
 
         _machines = await MachineService.GetMachinesAsync();
         _branches = await BranchService.GetBranchesAsync();

--- a/Components/Pages/Planning/LocalDeliveryPlanning.razor
+++ b/Components/Pages/Planning/LocalDeliveryPlanning.razor
@@ -1,7 +1,9 @@
 @page "/planning/local"
 @using CMetalsWS.Data
 @using System.Linq
+@using CMetalsWS.Security
 @using MudBlazor
+@attribute [Authorize(Policy = Permissions.PickingLists.ManageLoads)]
 
 @inject CMetalsWS.Services.PickingListService PickingListService
 @inject CMetalsWS.Services.TruckService TruckService
@@ -55,7 +57,9 @@
                 }
             </MudExpansionPanels>
 
-            <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!_selectedGroups.Any())" OnClick="CreateLoadFromSelected" Class="mt-4">Create Load with Selected</MudButton>
+            <AuthorizeView>
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!_selectedGroups.Any())" OnClick="CreateLoadFromSelected" Class="mt-4">Create Load with Selected</MudButton>
+            </AuthorizeView>
         </MudPaper>
     </MudItem>
     <MudItem xs="12" md="5">
@@ -100,7 +104,9 @@
                 </MudPaper>
 
                 <MudStack Row="true" Class="mt-4">
-                    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="SaveLoad" Disabled="@(_load.TruckId == null)">Save Load</MudButton>
+                    <AuthorizeView>
+                        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="SaveLoad" Disabled="@(_load.TruckId == null)">Save Load</MudButton>
+                    </AuthorizeView>
                     <MudButton Variant="Variant.Outlined" OnClick="ClearLoad">Clear</MudButton>
                 </MudStack>
             }

--- a/Components/Pages/Planning/OutOfTownPlanning.razor
+++ b/Components/Pages/Planning/OutOfTownPlanning.razor
@@ -1,7 +1,9 @@
 @page "/planning/out-of-town"
 @using CMetalsWS.Data
 @using System.Linq
+@using CMetalsWS.Security
 @using MudBlazor
+@attribute [Authorize(Policy = Permissions.PickingLists.ManageLoads)]
 
 @inject CMetalsWS.Services.PickingListService PickingListService
 @inject CMetalsWS.Services.TruckService TruckService
@@ -55,7 +57,9 @@
                 }
             </MudExpansionPanels>
 
-            <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!_selectedGroups.Any())" OnClick="CreateLoadFromSelected" Class="mt-4">Create Load with Selected</MudButton>
+            <AuthorizeView>
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!_selectedGroups.Any())" OnClick="CreateLoadFromSelected" Class="mt-4">Create Load with Selected</MudButton>
+            </AuthorizeView>
         </MudPaper>
     </MudItem>
     <MudItem xs="12" md="5">
@@ -100,7 +104,9 @@
                 </MudPaper>
 
                 <MudStack Row="true" Class="mt-4">
-                    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="SaveLoad" Disabled="@(_load.TruckId == null)">Save Load</MudButton>
+                    <AuthorizeView>
+                        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="SaveLoad" Disabled="@(_load.TruckId == null)">Save Load</MudButton>
+                    </AuthorizeView>
                     <MudButton Variant="Variant.Outlined" OnClick="ClearLoad">Clear</MudButton>
                 </MudStack>
             }

--- a/Components/Pages/Planning/PoolTruckPlanning.razor
+++ b/Components/Pages/Planning/PoolTruckPlanning.razor
@@ -1,7 +1,9 @@
 @page "/planning/pool"
 @using CMetalsWS.Data
 @using System.Linq
+@using CMetalsWS.Security
 @using MudBlazor
+@attribute [Authorize(Policy = Permissions.PickingLists.ManageLoads)]
 
 @inject CMetalsWS.Services.PickingListService PickingListService
 @inject CMetalsWS.Services.TruckService TruckService
@@ -55,7 +57,9 @@
                 }
             </MudExpansionPanels>
 
-            <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!_selectedGroups.Any())" OnClick="CreateLoadFromSelected" Class="mt-4">Create Load with Selected</MudButton>
+            <AuthorizeView>
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!_selectedGroups.Any())" OnClick="CreateLoadFromSelected" Class="mt-4">Create Load with Selected</MudButton>
+            </AuthorizeView>
         </MudPaper>
     </MudItem>
     <MudItem xs="12" md="5">
@@ -100,7 +104,9 @@
                 </MudPaper>
 
                 <MudStack Row="true" Class="mt-4">
-                    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="SaveLoad" Disabled="@(_load.TruckId == null)">Save Load</MudButton>
+                    <AuthorizeView>
+                        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="SaveLoad" Disabled="@(_load.TruckId == null)">Save Load</MudButton>
+                    </AuthorizeView>
                     <MudButton Variant="Variant.Outlined" OnClick="ClearLoad">Clear</MudButton>
                 </MudStack>
             }

--- a/Components/Pages/Profile.razor
+++ b/Components/Pages/Profile.razor
@@ -1,7 +1,9 @@
 @page "/profile"
 @using CMetalsWS.Data
+@using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.AspNetCore.Identity
+@attribute [Authorize]
 @using System.ComponentModel.DataAnnotations
 @inject AuthenticationStateProvider AuthStateProvider
 @inject UserManager<ApplicationUser> UserManager

--- a/Components/Pages/Schedule/CtlSchedule.razor
+++ b/Components/Pages/Schedule/CtlSchedule.razor
@@ -1,4 +1,6 @@
 @page "/schedule/ctl"
 @using CMetalsWS.Data
+@using CMetalsWS.Security
+@attribute [Authorize(Policy = Permissions.WorkOrders.Schedule)]
 
 <MachineScheduleBase Title="CTL Schedule" MachineCategory="@MachineCategory.CTL" Color="Color.Primary" />

--- a/Components/Pages/Schedule/LogisticsSchedule.razor
+++ b/Components/Pages/Schedule/LogisticsSchedule.razor
@@ -7,6 +7,8 @@
 @using Microsoft.AspNetCore.Components
 @using Microsoft.AspNetCore.Components.Forms
 @using CMetalsWS.Components.Pages.Schedule
+@using CMetalsWS.Security
+@attribute [Authorize(Policy = Permissions.PickingLists.ManageLoads)]
 
 @inject LoadService LoadService
 @inject PickingListService PickingListService
@@ -63,45 +65,47 @@
             }
 
             <!-- Add Load panel -->
-            <MudPaper Class="pa-4" Elevation="0" Width="300px">
-                @if (_addLoadOpen)
-                {
-                    <MudPaper Elevation="0" Class="pa-4 d-flex flex-column mud-background-gray rounded-lg">
-                        <EditForm Model="_newLoadModel" OnValidSubmit="OnValidLoadSubmit">
-                            <DataAnnotationsValidator />
-                            <MudTextField @bind-Value="_newLoadModel.Name"
-                                          For="@(() => _newLoadModel.Name)"
-                                          Placeholder="New Load Name"
-                                          Underline="false" />
-                            <MudSelect T="int"
-                                       @bind-Value="_newLoadModel.TruckId"
-                                       For="@(() => _newLoadModel.TruckId)"
-                                       Label="Truck">
-                                @foreach (var truck in _trucks)
-                                {
-                                    <MudSelectItem T="int" Value="@truck.Id">@truck.Description</MudSelectItem>
-                                }
-                            </MudSelect>
-                            <MudButton ButtonType="ButtonType.Submit"
-                                       Size="Size.Small"
-                                       Color="Color.Primary"
-                                       FullWidth="true"
-                                       Class="mt-2">Add Load</MudButton>
-                        </EditForm>
-                    </MudPaper>
-                }
-                else
-                {
-                    <MudButton OnClick="() => _addLoadOpen = true"
-                               Variant="Variant.Outlined"
-                               StartIcon="@Icons.Material.Filled.Add"
-                               Color="Color.Primary"
-                               Class="rounded-lg py-2"
-                               FullWidth="true">
-                        Add Load
-                    </MudButton>
-                }
-            </MudPaper>
+            <AuthorizeView>
+                <MudPaper Class="pa-4" Elevation="0" Width="300px">
+                    @if (_addLoadOpen)
+                    {
+                        <MudPaper Elevation="0" Class="pa-4 d-flex flex-column mud-background-gray rounded-lg">
+                            <EditForm Model="_newLoadModel" OnValidSubmit="OnValidLoadSubmit">
+                                <DataAnnotationsValidator />
+                                <MudTextField @bind-Value="_newLoadModel.Name"
+                                              For="@(() => _newLoadModel.Name)"
+                                              Placeholder="New Load Name"
+                                              Underline="false" />
+                                <MudSelect T="int"
+                                           @bind-Value="_newLoadModel.TruckId"
+                                           For="@(() => _newLoadModel.TruckId)"
+                                           Label="Truck">
+                                    @foreach (var truck in _trucks)
+                                    {
+                                        <MudSelectItem T="int" Value="@truck.Id">@truck.Description</MudSelectItem>
+                                    }
+                                </MudSelect>
+                                <MudButton ButtonType="ButtonType.Submit"
+                                           Size="Size.Small"
+                                           Color="Color.Primary"
+                                           FullWidth="true"
+                                           Class="mt-2">Add Load</MudButton>
+                            </EditForm>
+                        </MudPaper>
+                    }
+                    else
+                    {
+                        <MudButton OnClick="() => _addLoadOpen = true"
+                                   Variant="Variant.Outlined"
+                                   StartIcon="@Icons.Material.Filled.Add"
+                                   Color="Color.Primary"
+                                   Class="rounded-lg py-2"
+                                   FullWidth="true">
+                            Add Load
+                        </MudButton>
+                    }
+                </MudPaper>
+            </AuthorizeView>
         </ChildContent>
 
         <ItemRenderer>

--- a/Components/Pages/Schedule/PullingSchedule.razor
+++ b/Components/Pages/Schedule/PullingSchedule.razor
@@ -7,6 +7,8 @@
 @using Microsoft.AspNetCore.SignalR.Client
 @using CMetalsWS.Data
 @using CMetalsWS.Services
+@using CMetalsWS.Security
+@attribute [Authorize(Policy = Permissions.WorkOrders.Schedule)]
 
 @inject PickingListService PickingListService
 @inject BranchService BranchService

--- a/Components/Pages/Schedule/ScheduleTest.razor
+++ b/Components/Pages/Schedule/ScheduleTest.razor
@@ -1,4 +1,6 @@
 ﻿@page "/schedule/test"
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize]
 
 @using System.Linq
 @using MudBlazor

--- a/Components/Pages/Schedule/SlitterSchedule.razor
+++ b/Components/Pages/Schedule/SlitterSchedule.razor
@@ -1,4 +1,6 @@
 @page "/schedule/slitter"
 @using CMetalsWS.Data
+@using CMetalsWS.Security
+@attribute [Authorize(Policy = Permissions.WorkOrders.Schedule)]
 
 <MachineScheduleBase Title="Slitter Schedule" MachineCategory="@MachineCategory.Slitter" Color="Color.Secondary" />

--- a/Components/Pages/Weather.razor
+++ b/Components/Pages/Weather.razor
@@ -1,5 +1,6 @@
 ﻿@page "/weather"
-
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize]
 
 
 <PageTitle>Weather</PageTitle>


### PR DESCRIPTION
Refactored several pages to eliminate the `RZ9999` Razor context collision error. The error was caused by nesting `AuthorizeView` components inside a `MudTable`'s `RowTemplate`.

The fix involves pre-computing authorization booleans in the `@code` block and using `@if` statements to conditionally render UI elements. This has been applied to `Branches.razor`, `Roles.razor`, `ChatGroups.razor`, `Machines.razor`, `Trucks.razor`, `Users.razor`, `PickingLists.razor`, and `WorkOrders.razor`.

Also added page-level authorization to several pages as part of the ongoing RBAC implementation.