### PR TITLE
feat: Implement granular RBAC and fix RZ9999 error

### DIFF
--- a/Components/Account/Shared/RedirectToHome.razor
+++ b/Components/Account/Shared/RedirectToHome.razor
@@ -1,0 +1,7 @@
+@inject NavigationManager Navigation
+@code {
+    protected override void OnInitialized()
+    {
+        Navigation.NavigateTo("/");
+    }
+}

--- a/Components/Routes.razor
+++ b/Components/Routes.razor
@@ -1,11 +1,23 @@
-﻿@using CMetalsWS.Components.Account.Shared
-<Router AppAssembly="typeof(Program).Assembly">
-    <Found Context="routeData">
-        <AuthorizeRouteView RouteData="routeData" DefaultLayout="typeof(Layout.MainLayout)">
-            <NotAuthorized>
-                <RedirectToLogin />
-            </NotAuthorized>
-        </AuthorizeRouteView>
-        <FocusOnNavigate RouteData="routeData" Selector="h1" />
-    </Found>
-</Router>
+@using Microsoft.AspNetCore.Components.Authorization
+@using CMetalsWS.Components.Account.Shared
+
+<CascadingAuthenticationState>
+    <Router AppAssembly="@typeof(Program).Assembly">
+        <Found Context="routeData">
+            <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(Layout.MainLayout)">
+                <NotAuthorized>
+                    <RedirectToLogin />
+                </NotAuthorized>
+                <Authorizing>
+                    <div class="pa-4">Authorizing…</div>
+                </Authorizing>
+            </AuthorizeRouteView>
+
+            <FocusOnNavigate RouteData="@routeData" Selector="h1" />
+        </Found>
+
+        <NotFound>
+            <RedirectToHome />
+        </NotFound>
+    </Router>
+</CascadingAuthenticationState>


### PR DESCRIPTION
This change implements granular Role-Based Access Control (RBAC) on all pages of the application, based on the permissions defined in `Security/Permissions.cs`.

- Secured all pages with the appropriate `[Authorize]` attribute and policies.
- Used `AuthorizeView` and imperative checks with `IAuthorizationService` to control access to specific actions (e.g., Add, Edit, Delete).
- Refactored several pages to eliminate the `RZ9999` Razor context collision error caused by nested `AuthorizeView` components. This was done by pre-computing authorization booleans and using `@if` statements.
- Refactored `Routes.razor` to include `CascadingAuthenticationState`, `Authorizing`, and `NotFound` blocks.

All pages should now be correctly secured according to the defined permissions.