### PR TITLE
Adds logic to `PickingListDialog.razor` to automatically schedule the…

### DIFF
--- a/Components/Pages/Operations/Pickinglist/PickingListDialog.razor
+++ b/Components/Pages/Operations/Pickinglist/PickingListDialog.razor
@@ -333,19 +333,63 @@
 
     private void Cancel() => Dialog.Cancel();
 
+    private DateTime? CalculateAutoScheduleDate()
+    {
+        if (!Model.ShipDate.HasValue) return null;
+
+        var shippingDate = Model.ShipDate.Value.Date;
+        var pullDate = shippingDate.AddDays(-1);
+
+        if (pullDate.DayOfWeek == DayOfWeek.Saturday)
+        {
+            pullDate = pullDate.AddDays(-1); // Becomes Friday
+        }
+        else if (pullDate.DayOfWeek == DayOfWeek.Sunday)
+        {
+            pullDate = pullDate.AddDays(-2); // Becomes Friday
+        }
+
+        return pullDate.AddHours(8);
+    }
+
     private void OnMachineChanged(PickingListItem item, int? machineId)
     {
         item.MachineId = machineId;
-        if (machineId.HasValue)
+        var machine = machineId.HasValue ? Machines.FirstOrDefault(m => m.Id == machineId.Value) : null;
+        var autoScheduleDate = CalculateAutoScheduleDate();
+
+        if (machine != null)
         {
             item.Status = PickingLineStatus.AssignedPulling;
+
+            if (machine.Name.Contains("Sheet", StringComparison.OrdinalIgnoreCase))
+            {
+                if (autoScheduleDate.HasValue)
+                {
+                    item.ScheduledShipDate = autoScheduleDate;
+                    Snackbar.Add($"Item auto-scheduled for pulling on {item.ScheduledShipDate:yyyy-MM-dd HH:mm}.", Severity.Info);
+                }
+            }
+            else
+            {
+                // It's not a sheet machine. Clear the date only if it was the one we would have set automatically.
+                if (item.ScheduledShipDate.HasValue && item.ScheduledShipDate.Value == autoScheduleDate)
+                {
+                    item.ScheduledShipDate = null;
+                }
+            }
         }
-        else
+        else // Machine is unassigned
         {
-            // Revert status if machine is unassigned
             if (item.Status == PickingLineStatus.AssignedPulling)
             {
                 item.Status = PickingLineStatus.Pending;
+            }
+
+            // Also clear auto-scheduled date on unassign
+            if (item.ScheduledShipDate.HasValue && item.ScheduledShipDate.Value == autoScheduleDate)
+            {
+                item.ScheduledShipDate = null;
             }
         }
         StateHasChanged();

--- a/Components/Pages/Schedule/PullingSchedule.razor
+++ b/Components/Pages/Schedule/PullingSchedule.razor
@@ -47,7 +47,7 @@
                     @foreach (var pl in _unscheduled)
                     {
                         <MudListItem T="PickingList" Value="@pl">
-                            @pl.SalesOrderNumber - @pl.Customer.CustomerName
+                            @pl.SalesOrderNumber - @(pl.Customer?.CustomerName ?? "N/A")
                         </MudListItem>
                     }
                 </MudList>
@@ -128,7 +128,7 @@
                 End = x.Min.AddHours(1),
                 AllDay = false,
                 PickingList = x.PL,
-                Text = $"{x.PL.SalesOrderNumber} - {x.PL.Customer.CustomerName}"
+                Text = $"{x.PL.SalesOrderNumber} - {x.PL.Customer?.CustomerName ?? "N/A"}"
             })
             .OrderBy(i => i.Start)
             .ToList();


### PR DESCRIPTION
… pulling of an item when it is assigned to a "Sheet" machine.

The scheduled pull date is set to the weekday before the picking list's ship date, automatically skipping weekends (scheduling for Friday if the day before is Saturday or Sunday).

This enhances the scheduling process by providing an intelligent default for sheet machine operations.