### PR TITLE
Add message status indicators to chat

### DIFF
--- a/Components/Chat/ChatThreadWindow.razor
+++ b/Components/Chat/ChatThreadWindow.razor
@@ -6,6 +6,7 @@
 @using MudBlazor
 @using Microsoft.AspNetCore.Components.Web
 @using System.Security.Claims
+@using System.Linq
 
 @implements IAsyncDisposable
 
@@ -60,9 +61,28 @@
                             <div class="bubble">@m.Content</div>
                             <div class="meta-row">
                                 <span class="time">@m.Timestamp.ToLocalTime().ToString("h:mm tt")</span>
-                                @if (isOutgoing && m.Id == _lastSeenMessageId)
+                                @if (isOutgoing)
                                 {
-                                    <span class="seen">Seen</span>
+                                    <span class="status-icons">
+                                        @if (m.Delivered)
+                                        {
+                                            <MudIcon Icon="@Icons.Material.Filled.DoneAll" Class="delivered" />
+                                        }
+                                        else if (m.Sent)
+                                        {
+                                            <MudIcon Icon="@Icons.Material.Filled.Done" Class="sent" />
+                                        }
+                                    </span>
+
+                                    @if (m.SeenBy?.Any() == true)
+                                    {
+                                        <span class="seen-avatars">
+                                            @foreach (var u in m.SeenBy)
+                                            {
+                                                <MudAvatar Class="seen-avatar" Size="Size.Small" Image="@u.Avatar" Text="@((u.Avatar is null || u.Avatar == "") ? $"{u.FirstName?.FirstOrDefault()}{u.LastName?.FirstOrDefault()}" : null)" />
+                                            }
+                                        </span>
+                                    }
                                 }
                             </div>
                         </div>
@@ -80,12 +100,12 @@
             <EditForm Model="this" OnValidSubmit="SendMessageAsync">
                 <div class="composer">
                     <MudTextField Value="@_draft"
-                                  ValueChanged="@OnDraftChanged"
                                   Placeholder="Type a message"
                                   Class="input"
                                   Lines="1"
                                   Immediate="true"
-                                  OnKeyDown="HandleKeyDown" />
+                                  OnKeyDown="HandleKeyDown"
+                                  ValueChanged="@(EventCallback.Factory.Create<string>(this, OnDraftChanged))" />
                     <MudIconButton Icon="@Icons.Material.Filled.Send" Disabled="string.IsNullOrWhiteSpace(_draft)" ButtonType="ButtonType.Submit" />
                 </div>
             </EditForm>
@@ -106,7 +126,6 @@
     private string _currentUserId = "";
     private List<ChatMessage> _messages = new();
     private bool _isTyping = false;
-    private int _lastSeenMessageId = 0;
     private bool _autoStickToBottom = true;
     private System.Timers.Timer? _typingTimer;
     private bool _typingSent;
@@ -136,6 +155,17 @@
 
     private Task OnMessageReceived(ChatMessage message)
     {
+        if (message.SenderId == _currentUserId)
+        {
+            var pending = _messages.FirstOrDefault(m => m.Sent && !m.Delivered && m.Content == message.Content);
+            if (pending != null)
+            {
+                pending.Id = message.Id;
+                pending.Delivered = true;
+                return InvokeAsync(StateHasChanged);
+            }
+        }
+
         _messages.Add(message);
         if (_autoStickToBottom)
         {
@@ -154,9 +184,24 @@
         return Task.CompletedTask;
     }
 
-    private Task OnReadReceipt(int messageId)
+    private Task OnReadReceipt(int messageId, string userId)
     {
-        _lastSeenMessageId = messageId;
+        var msg = _messages.FirstOrDefault(m => m.Id == messageId);
+        if (msg != null)
+        {
+            msg.Seen = true;
+            if (ThreadGroup != null)
+            {
+                var user = ThreadGroup.ChatGroupUsers.FirstOrDefault(u => u.UserId == userId)?.User;
+                if (user != null && msg.SeenBy.All(u => u.Id != user.Id))
+                    msg.SeenBy.Add(user);
+            }
+            else if (ThreadUser != null)
+            {
+                if (msg.SeenBy.All(u => u.Id != ThreadUser.Id))
+                    msg.SeenBy.Add(ThreadUser);
+            }
+        }
         return InvokeAsync(StateHasChanged);
     }
 
@@ -201,7 +246,8 @@
         {
             SenderId = _currentUserId,
             Content = _draft,
-            Timestamp = DateTime.Now
+            Timestamp = DateTime.Now,
+            Sent = true
         };
         _messages.Add(tempMsg);
         var toSend = _draft;

--- a/Components/Chat/ChatThreadWindow.razor.css
+++ b/Components/Chat/ChatThreadWindow.razor.css
@@ -95,9 +95,31 @@
     margin-top: 4px;
 }
 
-.seen {
-    margin-left: 8px;
-    font-style: italic;
+.status-icons {
+    margin-left: 4px;
+}
+
+.status-icons .mud-icon-root {
+    font-size: 14px;
+    vertical-align: middle;
+}
+
+.seen-avatars {
+    display: inline-flex;
+    align-items: center;
+    margin-left: 4px;
+}
+
+.seen-avatars .mud-avatar-root {
+    width: 18px;
+    height: 18px;
+    font-size: 0.7rem;
+    border: 1px solid var(--mud-palette-background);
+    margin-left: -6px;
+}
+
+.seen-avatars .mud-avatar-root:first-child {
+    margin-left: 0;
 }
 
 .composer {

--- a/Data/ChatMessage.cs
+++ b/Data/ChatMessage.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
@@ -24,5 +25,17 @@ namespace CMetalsWS.Data
         // Foreign key for the chat group (for group messages)
         public int? ChatGroupId { get; set; }
         public ChatGroup? ChatGroup { get; set; }
+
+        [NotMapped]
+        public bool Sent { get; set; }
+
+        [NotMapped]
+        public bool Delivered { get; set; }
+
+        [NotMapped]
+        public bool Seen { get; set; }
+
+        [NotMapped]
+        public List<ApplicationUser> SeenBy { get; set; } = new();
     }
 }

--- a/Hubs/ChatHub.cs
+++ b/Hubs/ChatHub.cs
@@ -96,13 +96,14 @@ namespace CMetalsWS.Hubs
         {
             var readerId = GetUserIdOrThrow();
             // notify the partner that readerId has seen up to lastMessageId
-            return Clients.User(partnerId).SendAsync("ReceiveReadReceipt", lastMessageId);
+            return Clients.User(partnerId).SendAsync("ReceiveReadReceipt", lastMessageId, readerId);
         }
 
         public Task AckReadGroup(int groupId, int lastMessageId)
         {
+            var readerId = GetUserIdOrThrow();
             // broadcast to the group; clients can filter by sender if needed
-            return Clients.Group(groupId.ToString()).SendAsync("ReceiveReadReceipt", lastMessageId);
+            return Clients.Group(groupId.ToString()).SendAsync("ReceiveReadReceipt", lastMessageId, readerId);
         }
 
         public override async Task OnConnectedAsync()

--- a/Services/IChatClient.cs
+++ b/Services/IChatClient.cs
@@ -19,6 +19,6 @@ namespace CMetalsWS.Services
         event Func<ChatMessage, Task>? MessageReceived;
         event Func<string, bool, Task>? TypingChanged;   // (userId, isTyping)
         event Func<string, bool, Task>? PresenceChanged; // (userId, online)
-        event Func<int, Task>? ReadReceipt;              // (messageId)
+        event Func<int, string, Task>? ReadReceipt;      // (messageId, userId)
     }
 }

--- a/Services/SignalRChatClient.cs
+++ b/Services/SignalRChatClient.cs
@@ -14,7 +14,7 @@ namespace CMetalsWS.Services
         public event Func<ChatMessage, Task>? MessageReceived;
         public event Func<string, bool, Task>? TypingChanged;
         public event Func<string, bool, Task>? PresenceChanged;
-        public event Func<int, Task>? ReadReceipt;
+        public event Func<int, string, Task>? ReadReceipt;
 
         public SignalRChatClient(NavigationManager navigationManager)
         {
@@ -41,10 +41,10 @@ namespace CMetalsWS.Services
                     await TypingChanged.Invoke(userId, isTyping);
             });
 
-            _hubConnection.On<int>("ReceiveReadReceipt", async (messageId) =>
+            _hubConnection.On<int, string>("ReceiveReadReceipt", async (messageId, userId) =>
             {
                 if (ReadReceipt != null)
-                    await ReadReceipt.Invoke(messageId);
+                    await ReadReceipt.Invoke(messageId, userId);
             });
 
             // TODO: Implement presence handlers if needed


### PR DESCRIPTION
## Summary
- track sent, delivered and seen states on chat messages
- show delivery checkmarks and reader avatars in ChatThreadWindow
- include reader id in SignalR read receipts

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68bf56631e4c83338e1ebfc6499330e0