### PR TITLE
feat: add animated typing indicator to chat thread window

### DIFF
--- a/Components/Chat/ChatThreadWindow.razor
+++ b/Components/Chat/ChatThreadWindow.razor
@@ -71,8 +71,21 @@
                 @if (_isTyping)
                 {
                     <div class="message in">
-                        <MudAvatar Class="message__avatar" Size="Size.Small" />
-                        <div><div class="bubble">...</div></div>
+                        <MudAvatar Class="message__avatar"
+                                   Size="Size.Small"
+                                   Image="@ThreadUser?.Avatar"
+                                   Text="@(ThreadUser != null && string.IsNullOrWhiteSpace(ThreadUser.Avatar)
+                                       ? $"{ThreadUser.FirstName?.FirstOrDefault()}{ThreadUser.LastName?.FirstOrDefault()}"
+                                       : null)" />
+                        <div>
+                            <div class="bubble typing-bubble">
+                                <div class="typing-indicator">
+                                    <span></span>
+                                    <span></span>
+                                    <span></span>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 }
             </div>
@@ -80,7 +93,7 @@
             <EditForm Model="this" OnValidSubmit="SendMessageAsync">
                 <div class="composer">
                     <MudTextField Value="@_draft"
-                                  ValueChanged="@OnDraftChanged"
+                                  ValueChanged="@(async (string value) => await OnDraftChanged(value))"
                                   Placeholder="Type a message"
                                   Class="input"
                                   Lines="1"

--- a/Components/Chat/ChatThreadWindow.razor.css
+++ b/Components/Chat/ChatThreadWindow.razor.css
@@ -111,3 +111,42 @@
     flex-grow: 1;
     font-size: 16px;
 }
+
+.typing-bubble {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+}
+
+.typing-indicator {
+    display: flex;
+    gap: 4px;
+}
+
+.typing-indicator span {
+    width: 6px;
+    height: 6px;
+    background-color: var(--mud-palette-text-primary);
+    border-radius: 50%;
+    animation: typing-bounce 1.4s infinite both;
+}
+
+.typing-indicator span:nth-child(2) {
+    animation-delay: .2s;
+}
+
+.typing-indicator span:nth-child(3) {
+    animation-delay: .4s;
+}
+
+@keyframes typing-bounce {
+    0%, 80%, 100% {
+        opacity: .3;
+        transform: translateY(0);
+    }
+    40% {
+        opacity: 1;
+        transform: translateY(-4px);
+    }
+}


### PR DESCRIPTION
## Summary
- animate typing indicator with pulsing dots
- show user's avatar alongside typing indicator

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68bf5665e9508333aff366681bd3e972