### PR TITLE
Handle per-user read receipts in chat threads

### DIFF
--- a/Components/Chat/ChatThreadWindow.razor
+++ b/Components/Chat/ChatThreadWindow.razor
@@ -77,7 +77,7 @@
                                     @if (m.SeenBy?.Any() == true)
                                     {
                                         <span class="seen-avatars">
-                                            @foreach (var u in m.SeenBy)
+                                            @foreach (var u in m.SeenBy.Values)
                                             {
                                                 <MudAvatar Class="seen-avatar" Size="Size.Small" Image="@u.Avatar" Text="@((u.Avatar is null || u.Avatar == "") ? $"{u.FirstName?.FirstOrDefault()}{u.LastName?.FirstOrDefault()}" : null)" />
                                             }
@@ -189,17 +189,15 @@
         var msg = _messages.FirstOrDefault(m => m.Id == messageId);
         if (msg != null)
         {
-            msg.Seen = true;
             if (ThreadGroup != null)
             {
                 var user = ThreadGroup.ChatGroupUsers.FirstOrDefault(u => u.UserId == userId)?.User;
-                if (user != null && msg.SeenBy.All(u => u.Id != user.Id))
-                    msg.SeenBy.Add(user);
+                if (user != null)
+                    msg.SeenBy[user.Id] = user;
             }
             else if (ThreadUser != null)
             {
-                if (msg.SeenBy.All(u => u.Id != ThreadUser.Id))
-                    msg.SeenBy.Add(ThreadUser);
+                msg.SeenBy[ThreadUser.Id] = ThreadUser;
             }
         }
         return InvokeAsync(StateHasChanged);

--- a/Data/ChatMessage.cs
+++ b/Data/ChatMessage.cs
@@ -36,6 +36,6 @@ namespace CMetalsWS.Data
         public bool Seen { get; set; }
 
         [NotMapped]
-        public List<ApplicationUser> SeenBy { get; set; } = new();
+        public Dictionary<string, ApplicationUser> SeenBy { get; set; } = new();
     }
 }


### PR DESCRIPTION
## Summary
- Track read receipts per user on `ChatMessage`
- Render read receipt avatars from new per-user map
- Update read-receipt callback to populate per-user status data

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bf59ac999c8333bc8aadd1243d49d5