### PR TITLE
Refactor: Implement Dynamic Load Planning

### DIFF
--- a/Components/Layout/NavMenu.razor
+++ b/Components/Layout/NavMenu.razor
@@ -1,11 +1,14 @@
-﻿@implements IDisposable
+@implements IDisposable
+@using CMetalsWS.Data
 @using CMetalsWS.Security
+@using CMetalsWS.Services
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.Routing
 
 @inject NavigationManager NavigationManager
 @inject IAuthorizationService AuthorizationService
 @inject AuthenticationStateProvider AuthStateProvider
+@inject DestinationRegionService DestinationRegionService
 
 <MudNavMenu>
     <MudNavLink Href="" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Home">Home</MudNavLink>
@@ -87,9 +90,10 @@
     @if (canPickingLists)
     {
         <MudNavGroup text="Load Planning" Icon="@Icons.Material.Filled.LocalShipping" Title="Load Planning">
-            <MudNavLink Href="/planning/local" Icon="@Icons.Material.Filled.LocationOn">Local Delivery</MudNavLink>
-            <MudNavLink Href="/planning/pool" Icon="@Icons.Material.Filled.Pool">Pool Truck</MudNavLink>
-            <MudNavLink Href="/planning/out-of-town" Icon="@Icons.Material.Filled.Commute">Out of Town</MudNavLink>
+            @foreach (var region in _destinationRegions)
+            {
+                <MudNavLink Href="@($"/planning/load/{region.Id}")" Icon="@Icons.Material.Filled.LocationOn">@region.Name</MudNavLink>
+            }
         </MudNavGroup>
     }
 
@@ -123,6 +127,7 @@
 
 @code {
     private string? currentUrl;
+    private List<DestinationRegion> _destinationRegions = new();
 
     // permission flags
     private bool canUsers;
@@ -143,6 +148,7 @@
         currentUrl = NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
         NavigationManager.LocationChanged += OnLocationChanged;
         await ComputePermissionsAsync();
+        await LoadDestinationRegionsAsync();
     }
 
     private async Task ComputePermissionsAsync()
@@ -163,10 +169,16 @@
         isSupervisor = user.IsInRole("Supervisor");
     }
 
+    private async Task LoadDestinationRegionsAsync()
+    {
+        _destinationRegions = await DestinationRegionService.GetDestinationRegionsAsync();
+    }
+
     private async void OnLocationChanged(object? sender, LocationChangedEventArgs e)
     {
         currentUrl = NavigationManager.ToBaseRelativePath(e.Location);
         await ComputePermissionsAsync();
+        await LoadDestinationRegionsAsync();
         StateHasChanged();
     }
 

--- a/Components/Layout/NavMenu.razor
+++ b/Components/Layout/NavMenu.razor
@@ -16,54 +16,31 @@
     <MudNavLink Href="/dashboard" Icon="@Icons.Material.Filled.Dashboard">Dashboard</MudNavLink>
     <MudNavLink Href="/messages" Icon="@Icons.Material.Filled.Chat">Messages</MudNavLink>
 
-    @if (canUsers || canBranches || canRoles || canMachines || canTrucks)
-    {
-        <MudNavGroup text="Admin" Icon="@Icons.Material.Filled.AdminPanelSettings" Title="System Panel">
-            @if (canUsers)
-            {
-                <MudNavLink Href="/users" Icon="@Icons.Material.Filled.Person">Users</MudNavLink>
-            }
-            @if (canBranches)
-            {
-                <MudNavLink Href="/branches" Icon="@Icons.Material.Filled.LocationCity">Branches</MudNavLink>
-            }
-            @if (canRoles)
-            {
-                <MudNavLink Href="/roles" Icon="@Icons.Material.Filled.Security">Roles</MudNavLink>
-            }
-            @if (canMachines)
-            {
-                <MudNavLink Href="/machines" Icon="@Icons.Material.Filled.Build">Machines</MudNavLink>
-            }
-            @if (canTrucks)
-            {
-                <MudNavLink Href="/trucks" Icon="@Icons.Material.Filled.LocalShipping">Trucks</MudNavLink>
-            }
-            <MudNavLink Href="/admin/chatgroups" Icon="@Icons.Material.Filled.Chat">Chat Groups</MudNavLink>
-        </MudNavGroup>
-    }
-
-    @if (isManager)
-    {
-        <MudNavGroup text="Manager" Icon="@Icons.Material.Filled.SupervisorAccount" Title="Manager Panel">
-            <MudNavLink Href="/manager/chatgroups" Icon="@Icons.Material.Filled.Chat">Chat Groups</MudNavLink>
-        </MudNavGroup>
-    }
-
-    @if (isManager || isSupervisor)
-    {
-        <MudNavGroup text="System Panel" Icon="@Icons.Material.Filled.Settings" Title="System Panel">
-            @if (canViewCustomers)
-            {
-                <MudNavLink Href="/customers" Icon="@Icons.Material.Filled.People">Customers</MudNavLink>
-            }
-            @if (canManageCustomers)
-            {
-                <MudNavLink Href="/admin/destination-groups" Icon="@Icons.Material.Filled.GroupWork">Destination Groups</MudNavLink>
-                <MudNavLink Href="/admin/destination-regions" Icon="@Icons.Material.Filled.Public">Destination Regions</MudNavLink>
-            }
-        </MudNavGroup>
-    }
+    <MudNavGroup text="System Panel" Icon="@Icons.Material.Filled.Settings" Title="System Panel" Expanded="true">
+        <AuthorizeView Policy="@Permissions.Users.View">
+            <MudNavLink Href="/users" Icon="@Icons.Material.Filled.Person">Users</MudNavLink>
+        </AuthorizeView>
+        <AuthorizeView Policy="@Permissions.Roles.View">
+            <MudNavLink Href="/roles" Icon="@Icons.Material.Filled.Security">Roles</MudNavLink>
+        </AuthorizeView>
+        <AuthorizeView Policy="@Permissions.Branches.View">
+            <MudNavLink Href="/branches" Icon="@Icons.Material.Filled.LocationCity">Branches</MudNavLink>
+        </AuthorizeView>
+        <AuthorizeView Policy="@Permissions.Machines.View">
+            <MudNavLink Href="/machines" Icon="@Icons.Material.Filled.Build">Machines</MudNavLink>
+        </AuthorizeView>
+        <AuthorizeView Policy="@Permissions.Trucks.View">
+            <MudNavLink Href="/trucks" Icon="@Icons.Material.Filled.LocalShipping">Trucks</MudNavLink>
+        </AuthorizeView>
+        <AuthorizeView Policy="@Permissions.Customers.View">
+            <MudNavLink Href="/customers" Icon="@Icons.Material.Filled.People">Customer Manager</MudNavLink>
+        </AuthorizeView>
+        <AuthorizeView Policy="@Permissions.Customers.Manage">
+            <MudNavLink Href="/admin/destination-groups" Icon="@Icons.Material.Filled.GroupWork">Destination Groups</MudNavLink>
+            <MudNavLink Href="/admin/destination-regions" Icon="@Icons.Material.Filled.Public">Destination Regions</MudNavLink>
+        </AuthorizeView>
+        <MudNavLink Href="/admin/chatgroups" Icon="@Icons.Material.Filled.Chat">Chat Groups</MudNavLink>
+    </MudNavGroup>
 
     @if (canWorkOrders || canPickingLists)
     {
@@ -130,18 +107,9 @@
     private List<DestinationRegion> _destinationRegions = new();
 
     // permission flags
-    private bool canUsers;
-    private bool canBranches;
-    private bool canRoles;
-    private bool canMachines;
-    private bool canTrucks;
     private bool canWorkOrders;
     private bool canPickingLists;
     private bool canAssignPickingLists;
-    private bool isManager;
-    private bool isSupervisor;
-    private bool canViewCustomers;
-    private bool canManageCustomers;
 
     protected override async Task OnInitializedAsync()
     {
@@ -155,18 +123,9 @@
     {
         var user = (await AuthStateProvider.GetAuthenticationStateAsync()).User;
 
-        canViewCustomers = (await AuthorizationService.AuthorizeAsync(user, null, Permissions.Customers.View)).Succeeded;
-        canManageCustomers = (await AuthorizationService.AuthorizeAsync(user, null, Permissions.Customers.Manage)).Succeeded;
-        canUsers = (await AuthorizationService.AuthorizeAsync(user, null, Permissions.Users.View)).Succeeded;
-        canBranches = (await AuthorizationService.AuthorizeAsync(user, null, Permissions.Branches.View)).Succeeded;
-        canRoles = (await AuthorizationService.AuthorizeAsync(user, null, Permissions.Roles.View)).Succeeded;
-        canMachines = (await AuthorizationService.AuthorizeAsync(user, null, Permissions.Machines.View)).Succeeded;
-        canTrucks = (await AuthorizationService.AuthorizeAsync(user, null, Permissions.Trucks.View)).Succeeded;
         canWorkOrders = (await AuthorizationService.AuthorizeAsync(user, null, Permissions.WorkOrders.View)).Succeeded;
         canPickingLists = (await AuthorizationService.AuthorizeAsync(user, null, Permissions.PickingLists.View)).Succeeded;
         canAssignPickingLists = (await AuthorizationService.AuthorizeAsync(user, null, Permissions.PickingLists.Assign)).Succeeded;
-        isManager = user.IsInRole("Manager");
-        isSupervisor = user.IsInRole("Supervisor");
     }
 
     private async Task LoadDestinationRegionsAsync()

--- a/Components/Pages/Admin/DestinationRegions.razor
+++ b/Components/Pages/Admin/DestinationRegions.razor
@@ -5,6 +5,7 @@
 @attribute [Authorize(Policy = Permissions.Customers.Manage)]
 
 @inject DestinationRegionService DestinationRegionService
+@inject BranchService BranchService
 @inject IDialogService DialogService
 @inject ISnackbar Snackbar
 
@@ -14,7 +15,7 @@
         <MudButton Color="Color.Primary"
                    Variant="Variant.Filled"
                    StartIcon="@Icons.Material.Filled.Add"
-                   OnClick="(() => { _selectedRegion = new DestinationRegion(); _dialogOpen = true; })">
+                   OnClick="OpenCreateDialog">
             New Region
         </MudButton>
     </MudStack>
@@ -23,14 +24,18 @@
         <HeaderContent>
             <MudTh>Id</MudTh>
             <MudTh>Name</MudTh>
+            <MudTh>Branches</MudTh>
             <MudTh>Actions</MudTh>
         </HeaderContent>
         <RowTemplate>
             <MudTd DataLabel="Id">@context.Id</MudTd>
             <MudTd DataLabel="Name">@context.Name</MudTd>
+            <MudTd DataLabel="Branches">
+                @string.Join(", ", context.Branches.Select(b => b.Name))
+            </MudTd>
             <MudTd DataLabel="Actions">
-                <MudIconButton Icon="@Icons.Material.Filled.Edit" Variant="Variant.Outlined" Color="Color.Primary" Size="Size.Small" OnClick="(() => { _selectedRegion = context; _dialogOpen = true; })" />
-                <MudIconButton Icon="@Icons.Material.Filled.Delete" Variant="Variant.Outlined" Color="Color.Error" Size="Size.Small" OnClick="(() => OnDelete(context.Id))" />
+                <MudIconButton Icon="@Icons.Material.Filled.Edit" Variant="Variant.Outlined" Color="Color.Primary" Size="Size.Small" OnClick="() => OpenEditDialog(context)" />
+                <MudIconButton Icon="@Icons.Material.Filled.Delete" Variant="Variant.Outlined" Color="Color.Error" Size="Size.Small" OnClick="() => OnDelete(context.Id)" />
             </MudTd>
         </RowTemplate>
     </MudTable>
@@ -42,6 +47,12 @@
     </TitleContent>
     <DialogContent>
         <MudTextField @bind-Value="_selectedRegion.Name" Label="Name" Required="true" />
+        <MudSelect T="int" Label="Branches" MultiSelection="true" @bind-SelectedValues="_selectedBranchIds">
+            @foreach (var branch in _branches)
+            {
+                <MudSelectItem T="int" Value="@branch.Id">@branch.Name</MudSelectItem>
+            }
+        </MudSelect>
     </DialogContent>
     <DialogActions>
         <MudButton OnClick="() => _dialogOpen = false">Cancel</MudButton>
@@ -51,19 +62,36 @@
 
 @code {
     private List<DestinationRegion> _regions = new();
+    private List<Branch> _branches = new();
     private bool _dialogOpen;
     private DestinationRegion _selectedRegion = new();
+    private IEnumerable<int> _selectedBranchIds = new List<int>();
     private DialogOptions _dialogOptions = new() { MaxWidth = MaxWidth.ExtraSmall, FullWidth = true };
 
     protected override async Task OnInitializedAsync()
     {
-        await LoadRegions();
+        await LoadData();
     }
 
-    private async Task LoadRegions()
+    private async Task LoadData()
     {
         _regions = await DestinationRegionService.GetDestinationRegionsAsync();
+        _branches = await BranchService.GetBranchesAsync();
         StateHasChanged();
+    }
+
+    private void OpenCreateDialog()
+    {
+        _selectedRegion = new DestinationRegion();
+        _selectedBranchIds = new List<int>();
+        _dialogOpen = true;
+    }
+
+    private void OpenEditDialog(DestinationRegion region)
+    {
+        _selectedRegion = region;
+        _selectedBranchIds = region.Branches.Select(b => b.Id).ToList();
+        _dialogOpen = true;
     }
 
     private async Task SaveRegion()
@@ -76,16 +104,16 @@
 
         if (_selectedRegion.Id == 0)
         {
-            await DestinationRegionService.CreateAsync(_selectedRegion);
+            await DestinationRegionService.CreateAsync(_selectedRegion, _selectedBranchIds);
             Snackbar.Add("Region created successfully.", Severity.Success);
         }
         else
         {
-            await DestinationRegionService.UpdateAsync(_selectedRegion);
+            await DestinationRegionService.UpdateAsync(_selectedRegion, _selectedBranchIds);
             Snackbar.Add("Region updated successfully.", Severity.Success);
         }
         _dialogOpen = false;
-        await LoadRegions();
+        await LoadData();
     }
 
     private async Task OnDelete(int id)
@@ -107,7 +135,7 @@
         {
             await DestinationRegionService.DeleteAsync(id);
             Snackbar.Add("Region deleted successfully.", Severity.Success);
-            await LoadRegions();
+            await LoadData();
         }
     }
 }

--- a/Components/Pages/Customers/Customers.razor
+++ b/Components/Pages/Customers/Customers.razor
@@ -1,9 +1,10 @@
-﻿@page "/customers"
+@page "/customers"
 @using CMetalsWS.Data
 @using CMetalsWS.Services
 @using CMetalsWS.Models
 @using MudBlazor
 @using CMetalsWS.Components.Pages.Customers
+@using CMetalsWS.Security
 @attribute [Authorize(Policy = Permissions.Customers.View)]
 
 @inject CustomerService CustomerService
@@ -76,7 +77,12 @@
                 <MudChip T="string" Color="@(context.Active ? Color.Success : Color.Error)" Size="Size.Small">@(context.Active ? "Active" : "Inactive")</MudChip>
             </MudTd>
             <MudTd DataLabel="Actions">
-                <MudIconButton Icon="@Icons.Material.Filled.Edit" Variant="Variant.Outlined" Color="Color.Primary" Size="Size.Small" OnClick="(() => OpenEditDialog(context.Id))" />
+                <AuthorizeView Policy="@Permissions.Customers.Edit" Context="authContext">
+                    <MudIconButton Icon="@Icons.Material.Filled.Edit" Variant="Variant.Outlined" Color="Color.Primary" Size="Size.Small" OnClick="() => OpenEditDialog(context.Id)" />
+                </AuthorizeView>
+                <AuthorizeView Policy="@Permissions.Customers.Delete" Context="authContext">
+                    <MudIconButton Icon="@Icons.Material.Filled.Delete" Variant="Variant.Outlined" Color="Color.Error" Size="Size.Small" OnClick="() => OnDelete(context.Id)" />
+                </AuthorizeView>
             </MudTd>
         </RowTemplate>
         <PagerContent>
@@ -168,4 +174,27 @@
         }
     }
 
+    private async Task OnDelete(int customerId)
+    {
+        var customer = await CustomerService.GetByIdAsync(customerId);
+        if (customer == null)
+        {
+            Snackbar.Add("Customer not found.", Severity.Error);
+            return;
+        }
+
+        var result = await DialogService.ShowMessageBox(
+            "Delete Confirmation",
+            $"Are you sure you want to delete customer '{customer.CustomerName}'?",
+            yesText: "Delete",
+            cancelText: "Cancel"
+        );
+
+        if (result == true)
+        {
+            await CustomerService.DeleteCustomerAsync(customerId);
+            Snackbar.Add("Customer deleted successfully.", Severity.Success);
+            await _table.ReloadServerData();
+        }
+    }
 }

--- a/Components/Pages/Customers/EditCustomerDialog.razor
+++ b/Components/Pages/Customers/EditCustomerDialog.razor
@@ -1,5 +1,9 @@
 @using CMetalsWS.Data
+@using CMetalsWS.Services
 @using MudBlazor
+
+@inject DestinationRegionService DestinationRegionService
+@inject DestinationGroupService DestinationGroupService
 
 <MudDialog>
     <TitleContent>
@@ -20,12 +24,15 @@
                 </MudItem>
 
                 <MudItem xs="12" sm="6">
-                    <MudTextField @bind-Value="Customer.BusinessHours" Label="Business Hours" />
+                    <MudTimePicker Label="Receiving Hours Start" @bind-Time="Customer.ReceivingHourStart" />
                 </MudItem>
+                <MudItem xs="12" sm="6">
+                    <MudTimePicker Label="Receiving Hours End" @bind-Time="Customer.ReceivingHourEnd" />
+                </MudItem>
+
                 <MudItem xs="12" sm="6">
                     <MudTextField @bind-Value="Customer.ContactNumber" Label="Contact Number" />
                 </MudItem>
-
                 <MudItem xs="12" sm="6">
                     <MudTextField @bind-Value="Customer.ContactName" Label="Contact Name" />
                 </MudItem>
@@ -35,6 +42,23 @@
 
                 <MudItem xs="12">
                     <MudDivider />
+                </MudItem>
+
+                <MudItem xs="12" sm="6">
+                    <MudSelect T="int?" @bind-Value="Customer.DestinationRegionId" Label="Destination Region">
+                        @foreach (var region in _regions)
+                        {
+                            <MudSelectItem T="int?" Value="@region.Id">@region.Name</MudSelectItem>
+                        }
+                    </MudSelect>
+                </MudItem>
+                <MudItem xs="12" sm="6">
+                    <MudSelect T="int?" @bind-Value="Customer.DestinationGroupId" Label="Destination Group">
+                        @foreach (var group in _groups)
+                        {
+                            <MudSelectItem T="int?" Value="@group.Id">@group.Name</MudSelectItem>
+                        }
+                    </MudSelect>
                 </MudItem>
 
                 <MudItem xs="12" sm="4">
@@ -81,6 +105,19 @@
     [Parameter] public bool IsNew { get; set; }
 
     private MudForm _form = default!;
+    private List<DestinationRegion> _regions = new();
+    private List<DestinationGroup> _groups = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadData();
+    }
+
+    private async Task LoadData()
+    {
+        _regions = await DestinationRegionService.GetDestinationRegionsAsync();
+        _groups = await DestinationGroupService.GetDestinationGroupsAsync();
+    }
 
     private void Cancel() => MudDialog.Cancel();
 

--- a/Components/Pages/Planning/UnifiedLoadPlanning.razor
+++ b/Components/Pages/Planning/UnifiedLoadPlanning.razor
@@ -1,0 +1,324 @@
+@page "/planning/load/{DestinationRegionId:int}"
+@using CMetalsWS.Data
+@using System.Linq
+@using CMetalsWS.Security
+@using MudBlazor
+@attribute [Authorize(Policy = Permissions.PickingLists.ManageLoads)]
+
+@inject CMetalsWS.Services.PickingListService PickingListService
+@inject CMetalsWS.Services.TruckService TruckService
+@inject CMetalsWS.Services.LoadService LoadService
+@inject CMetalsWS.Services.DestinationRegionService DestinationRegionService
+@inject IDialogService DialogService
+@inject ISnackbar Snackbar
+
+<MudText Typo="Typo.h4">Load Planning: @_region?.Name</MudText>
+
+<MudGrid>
+    <MudItem xs="12" md="7">
+        <MudPaper Class="pa-4" Style="height: 100%;">
+            <MudText Typo="Typo.h6">Available Picking Lists</MudText>
+
+            <MudExpansionPanels MultiExpansion="true">
+                @foreach (var group in _groupedPickingLists)
+                {
+                    <MudExpansionPanel>
+                        <TitleContent>
+                            <MudStack Row="true" AlignItems="AlignItems.Center">
+                                <MudCheckBox T="bool" Value="@(_selectedGroups.Contains(group))" ValueChanged="@((bool val) => OnGroupChecked(val, group))" />
+                                <MudText>SO: @group.Key</MudText>
+                                <MudText>Customer: @group.First().Customer?.CustomerName</MudText>
+                                <MudText>Weight: @group.SelectMany(pl => pl.Items).Sum(pli => pli.PulledWeight) lbs</MudText>
+                                <MudText>Status: @group.First().Status</MudText>
+                                <MudIconButton Icon="@Icons.Material.Filled.Splitscreen" Size="Size.Small" OnClick="@(() => OpenPartialLoadDialog(group.ToList()))" />
+                            </MudStack>
+                        </TitleContent>
+                        <ChildContent>
+                            <MudSimpleTable Dense="true" Striped="true">
+                                <thead>
+                                    <tr>
+                                        <th>Item ID</th>
+                                        <th>Description</th>
+                                        <th>Pulled Wt.</th>
+                                        <th>Pulled Qty.</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach (var item in group.SelectMany(pl => pl.Items).OrderBy(i => i.Id))
+                                    {
+                                        <tr>
+                                            <td>@item.ItemId</td>
+                                            <td>@item.ItemDescription</td>
+                                            <td>@item.PulledWeight</td>
+                                            <td>@item.PulledQuantity</td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </MudSimpleTable>
+                        </ChildContent>
+                    </MudExpansionPanel>
+                }
+            </MudExpansionPanels>
+
+            <AuthorizeView>
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!_selectedGroups.Any())" OnClick="CreateLoadFromSelected" Class="mt-4">Create Load with Selected</MudButton>
+            </AuthorizeView>
+        </MudPaper>
+    </MudItem>
+    <MudItem xs="12" md="5">
+        <MudPaper Class="pa-4" Style="height: 100%;">
+            <MudText Typo="Typo.h6">Load Builder</MudText>
+            @if (_load != null)
+            {
+                <MudSelect T="int?" Label="Truck" Value="_load.TruckId" ValueChanged="@OnTruckChanged" For="@(() => _load.TruckId)">
+                    @foreach (var truck in _trucks)
+                    {
+                        <MudSelectItem Value="@truck.Id">@truck.Name (@truck.CapacityWeight lbs)</MudSelectItem>
+                    }
+                </MudSelect>
+                <MudDatePicker Label="Shipping Date" @bind-Date="_load.ShippingDate" />
+                <MudTextField Label="Notes" @bind-Value="_load.Notes" Lines="2" />
+                <MudText Typo="Typo.caption" Class="mt-2">Load Capacity:</MudText>
+                <MudProgressLinear Color="@_loadCapacityColor" Value="@((double)_loadCapacity)" Class="my-1" />
+                <MudText Typo="Typo.body2"><strong>Total Weight:</strong> @_load.TotalWeight lbs</MudText>
+
+                <MudPaper Class="mt-4" Outlined="true">
+                    <MudToolBar>
+                        <MudText Typo="Typo.subtitle1">Items in Load</MudText>
+                    </MudToolBar>
+                    <MudContainer Style="max-height: 300px; overflow-y: auto">
+                        @foreach (var item in _itemsInLoad)
+                        {
+                            <MudDropZone T="LoadItem" OnItemDropped="ItemDropped" Identifier="@(item.PickingListItemId.ToString())">
+                                <MudPaper Elevation="2" Class="pa-2 ma-1">
+                                    <MudGrid>
+                                        <MudItem xs="1">@item.StopSequence</MudItem>
+                                        <MudItem xs="3">@item.PickingListItem.PickingList.SalesOrderNumber</MudItem>
+                                        <MudItem xs="4">@item.PickingListItem.PickingList.Customer.CustomerName</MudItem>
+                                        <MudItem xs="2" Style="text-align:right">@item.ShippedWeight.ToString("N2")</MudItem>
+                                        <MudItem xs="1">
+                                            <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small" OnClick="@(() => RemoveItemFromLoad(item))" />
+                                        </MudItem>
+                                    </MudGrid>
+                                </MudPaper>
+                            </MudDropZone>
+                        }
+                    </MudContainer>
+                </MudPaper>
+
+                <MudStack Row="true" Class="mt-4">
+                    <AuthorizeView>
+                        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="SaveLoad" Disabled="@(_load.TruckId == null)">Save Load</MudButton>
+                    </AuthorizeView>
+                    <MudButton Variant="Variant.Outlined" OnClick="ClearLoad">Clear</MudButton>
+                </MudStack>
+            }
+            else
+            {
+                <MudText>Select picking lists or use the partial load action to start building a load.</MudText>
+            }
+        </MudPaper>
+    </MudItem>
+</MudGrid>
+
+@code {
+    [Parameter]
+    public int DestinationRegionId { get; set; }
+
+    private DestinationRegion? _region;
+    private List<IGrouping<string, PickingList>> _groupedPickingLists = new();
+    private HashSet<IGrouping<string, PickingList>> _selectedGroups = new();
+    private Load? _load;
+    private List<LoadItem> _itemsInLoad = new();
+    private List<Truck> _trucks = new();
+
+    protected override async Task OnParametersSetAsync()
+    {
+        await LoadData();
+    }
+
+    private async Task LoadData()
+    {
+        _region = await DestinationRegionService.GetByIdAsync(DestinationRegionId);
+        if (_region == null)
+        {
+            Snackbar.Add("Destination region not found.", Severity.Error);
+            return;
+        }
+
+        var allPickingLists = await PickingListService.GetAvailableForLoadingAsync();
+        _groupedPickingLists = allPickingLists
+            .Where(p => p.Customer?.DestinationRegionId == DestinationRegionId)
+            .GroupBy(p => p.SalesOrderNumber)
+            .ToList();
+        _trucks = await TruckService.GetTrucksAsync();
+        StateHasChanged();
+    }
+
+    private void OnGroupChecked(bool isChecked, IGrouping<string, PickingList> group)
+    {
+        if (isChecked)
+        {
+            _selectedGroups.Add(group);
+        }
+        else
+        {
+            _selectedGroups.Remove(group);
+        }
+        StateHasChanged();
+    }
+
+    private void CreateLoadFromSelected()
+    {
+        if (!_selectedGroups.Any()) return;
+
+        _load = new Load { ShippingDate = DateTime.Today };
+        _itemsInLoad.Clear();
+
+        var allItems = _selectedGroups.SelectMany(g => g).SelectMany(pl => pl.Items);
+        foreach (var item in allItems)
+        {
+            _itemsInLoad.Add(new LoadItem
+            {
+                PickingListItemId = item.Id,
+                PickingListItem = item,
+                ShippedWeight = item.PulledWeight
+            });
+        }
+        RecalculateStopSequence();
+        UpdateLoadCapacity();
+    }
+
+    private void AddToLoad(IEnumerable<PickingListItem> itemsToAdd)
+    {
+        _load ??= new Load { ShippingDate = DateTime.Today };
+
+        foreach (var item in itemsToAdd)
+        {
+            if (!_itemsInLoad.Any(li => li.PickingListItemId == item.Id))
+            {
+                _itemsInLoad.Add(new LoadItem
+                {
+                    PickingListItemId = item.Id,
+                    PickingListItem = item,
+                    ShippedWeight = item.PulledWeight
+                });
+            }
+        }
+        RecalculateStopSequence();
+        UpdateLoadCapacity();
+    }
+
+    private void RemoveItemFromLoad(LoadItem item)
+    {
+        _itemsInLoad.Remove(item);
+        RecalculateStopSequence();
+        UpdateLoadCapacity();
+    }
+
+    private async Task SaveLoad()
+    {
+        if (_load is null) return;
+
+        _load.Items = _itemsInLoad;
+        try
+        {
+            await LoadService.CreateAsync(_load);
+            Snackbar.Add("Load saved successfully!", Severity.Success);
+            await LoadData();
+            ClearLoad();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Failed to save load: {ex.Message}", Severity.Error);
+        }
+    }
+
+    private void ClearLoad()
+    {
+        _load = null;
+        _itemsInLoad.Clear();
+        _selectedGroups.Clear();
+        _loadCapacity = 0;
+        StateHasChanged();
+    }
+
+    private void ItemDropped(MudItemDropInfo<LoadItem> dropItem)
+    {
+        if (dropItem.Item == null || dropItem.DropzoneIdentifier == null) return;
+
+        var itemToMove = dropItem.Item;
+        var targetIdentifier = dropItem.DropzoneIdentifier;
+        var targetItem = _itemsInLoad.FirstOrDefault(x => x.PickingListItemId.ToString() == targetIdentifier);
+
+        if (targetItem == null) return;
+
+        _itemsInLoad.Remove(itemToMove);
+        var targetIndex = _itemsInLoad.IndexOf(targetItem);
+        _itemsInLoad.Insert(targetIndex, itemToMove);
+
+        RecalculateStopSequence();
+        StateHasChanged();
+    }
+
+    private void RecalculateStopSequence()
+    {
+        for (int i = 0; i < _itemsInLoad.Count; i++)
+        {
+            _itemsInLoad[i].StopSequence = i + 1;
+        }
+    }
+
+    private decimal _loadCapacity;
+    private Color _loadCapacityColor = Color.Success;
+
+    private void OnTruckChanged(int? truckId)
+    {
+        if (_load != null)
+        {
+            _load.TruckId = truckId;
+            UpdateLoadCapacity();
+        }
+    }
+
+    private void UpdateLoadCapacity()
+    {
+        if (_load == null)
+        {
+            _loadCapacity = 0;
+            return;
+        }
+
+        _load.TotalWeight = _itemsInLoad.Sum(i => i.ShippedWeight);
+        var truck = _trucks.FirstOrDefault(t => t.Id == _load.TruckId);
+
+        if (truck == null || truck.CapacityWeight == 0)
+        {
+            _loadCapacity = _load.TotalWeight > 0 ? 100 : 0;
+        }
+        else
+        {
+            _loadCapacity = (_load.TotalWeight / truck.CapacityWeight) * 100;
+        }
+
+        if (_loadCapacity > 100) _loadCapacityColor = Color.Error;
+        else if (_loadCapacity > 85) _loadCapacityColor = Color.Warning;
+        else _loadCapacityColor = Color.Success;
+    }
+
+    private async Task OpenPartialLoadDialog(List<PickingList> pickingLists)
+    {
+        var parameters = new DialogParameters
+        {
+            ["PickingListItems"] = pickingLists.SelectMany(g => g.Items).ToList()
+        };
+
+        var dialog = await DialogService.ShowAsync<PartialLoadDialog>("Partial Load Selection", parameters);
+        var result = await dialog.Result;
+
+        if (result != null && !result.Canceled && result.Data is List<PickingListItem> selectedItems)
+        {
+            AddToLoad(selectedItems);
+        }
+    }
+}

--- a/Components/Pages/Planning/UnifiedLoadPlanning.razor
+++ b/Components/Pages/Planning/UnifiedLoadPlanning.razor
@@ -131,14 +131,22 @@
     private Load? _load;
     private List<LoadItem> _itemsInLoad = new();
     private List<Truck> _trucks = new();
+    private int _previousDestinationRegionId;
 
     protected override async Task OnParametersSetAsync()
     {
-        await LoadData();
+        if (_previousDestinationRegionId != DestinationRegionId)
+        {
+            await LoadData();
+            _previousDestinationRegionId = DestinationRegionId;
+        }
     }
 
     private async Task LoadData()
     {
+        ClearLoad();
+        _groupedPickingLists.Clear();
+
         _region = await DestinationRegionService.GetByIdAsync(DestinationRegionId);
         if (_region == null)
         {

--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -46,6 +46,11 @@ namespace CMetalsWS.Data
         {
             base.OnModelCreating(modelBuilder);
 
+            // DestinationRegion <-> Branch (Many-to-Many)
+            modelBuilder.Entity<DestinationRegion>()
+                .HasMany(dr => dr.Branches)
+                .WithMany(b => b.DestinationRegions)
+                .UsingEntity(j => j.ToTable("DestinationRegionBranch"));
 
             // Machine -> Branch
             modelBuilder.Entity<Machine>()

--- a/Data/Branch.cs
+++ b/Data/Branch.cs
@@ -23,5 +23,6 @@ namespace CMetalsWS.Data
         public ICollection<Truck> Trucks { get; set; } = new List<Truck>();
         public ICollection<WorkOrder> WorkOrders { get; set; } = new List<WorkOrder>();
         public ICollection<PickingList> PickingLists { get; set; } = new List<PickingList>();
+        public ICollection<DestinationRegion> DestinationRegions { get; set; } = new List<DestinationRegion>();
     }
 }

--- a/Data/DestinationRegion.cs
+++ b/Data/DestinationRegion.cs
@@ -4,5 +4,6 @@ namespace CMetalsWS.Data
     {
         public int Id { get; set; }
         public string Name { get; set; } = default!;
+        public ICollection<Branch> Branches { get; set; } = new List<Branch>();
     }
 }

--- a/Migrations/20250913125950_RefactorCustomerAndAddDynamicRegions.Designer.cs
+++ b/Migrations/20250913125950_RefactorCustomerAndAddDynamicRegions.Designer.cs
@@ -12,8 +12,8 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CMetalsWS.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20250913124651_initialcreate")]
-    partial class initialcreate
+    [Migration("20250913125950_RefactorCustomerAndAddDynamicRegions")]
+    partial class RefactorCustomerAndAddDynamicRegions
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -24,6 +24,21 @@ namespace CMetalsWS.Migrations
                 .HasAnnotation("Relational:MaxIdentifierLength", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+
+            modelBuilder.Entity("BranchDestinationRegion", b =>
+                {
+                    b.Property<int>("BranchesId")
+                        .HasColumnType("int");
+
+                    b.Property<int>("DestinationRegionsId")
+                        .HasColumnType("int");
+
+                    b.HasKey("BranchesId", "DestinationRegionsId");
+
+                    b.HasIndex("DestinationRegionsId");
+
+                    b.ToTable("DestinationRegionBranch", (string)null);
+                });
 
             modelBuilder.Entity("CMetalsWS.Data.ApplicationRole", b =>
                 {
@@ -1439,6 +1454,21 @@ namespace CMetalsWS.Migrations
                     b.HasKey("UserId", "LoginProvider", "Name");
 
                     b.ToTable("AspNetUserTokens", (string)null);
+                });
+
+            modelBuilder.Entity("BranchDestinationRegion", b =>
+                {
+                    b.HasOne("CMetalsWS.Data.Branch", null)
+                        .WithMany()
+                        .HasForeignKey("BranchesId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("CMetalsWS.Data.DestinationRegion", null)
+                        .WithMany()
+                        .HasForeignKey("DestinationRegionsId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
                 });
 
             modelBuilder.Entity("CMetalsWS.Data.ApplicationUser", b =>

--- a/Migrations/20250913125950_RefactorCustomerAndAddDynamicRegions.cs
+++ b/Migrations/20250913125950_RefactorCustomerAndAddDynamicRegions.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace CMetalsWS.Migrations
 {
     /// <inheritdoc />
-    public partial class initialcreate : Migration
+    public partial class RefactorCustomerAndAddDynamicRegions : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
@@ -292,6 +292,30 @@ namespace CMetalsWS.Migrations
                         principalTable: "DestinationRegions",
                         principalColumn: "Id",
                         onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "DestinationRegionBranch",
+                columns: table => new
+                {
+                    BranchesId = table.Column<int>(type: "int", nullable: false),
+                    DestinationRegionsId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DestinationRegionBranch", x => new { x.BranchesId, x.DestinationRegionsId });
+                    table.ForeignKey(
+                        name: "FK_DestinationRegionBranch_Branches_BranchesId",
+                        column: x => x.BranchesId,
+                        principalTable: "Branches",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_DestinationRegionBranch_DestinationRegions_DestinationRegionsId",
+                        column: x => x.DestinationRegionsId,
+                        principalTable: "DestinationRegions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
                 });
 
             migrationBuilder.CreateTable(
@@ -1038,6 +1062,11 @@ namespace CMetalsWS.Migrations
                 column: "Province");
 
             migrationBuilder.CreateIndex(
+                name: "IX_DestinationRegionBranch_DestinationRegionsId",
+                table: "DestinationRegionBranch",
+                column: "DestinationRegionsId");
+
+            migrationBuilder.CreateIndex(
                 name: "IX_InventoryItems_BranchId",
                 table: "InventoryItems",
                 column: "BranchId");
@@ -1244,6 +1273,9 @@ namespace CMetalsWS.Migrations
 
             migrationBuilder.DropTable(
                 name: "CityCentroid");
+
+            migrationBuilder.DropTable(
+                name: "DestinationRegionBranch");
 
             migrationBuilder.DropTable(
                 name: "InventoryItems");

--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -22,6 +22,21 @@ namespace CMetalsWS.Migrations
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
 
+            modelBuilder.Entity("BranchDestinationRegion", b =>
+                {
+                    b.Property<int>("BranchesId")
+                        .HasColumnType("int");
+
+                    b.Property<int>("DestinationRegionsId")
+                        .HasColumnType("int");
+
+                    b.HasKey("BranchesId", "DestinationRegionsId");
+
+                    b.HasIndex("DestinationRegionsId");
+
+                    b.ToTable("DestinationRegionBranch", (string)null);
+                });
+
             modelBuilder.Entity("CMetalsWS.Data.ApplicationRole", b =>
                 {
                     b.Property<string>("Id")
@@ -1436,6 +1451,21 @@ namespace CMetalsWS.Migrations
                     b.HasKey("UserId", "LoginProvider", "Name");
 
                     b.ToTable("AspNetUserTokens", (string)null);
+                });
+
+            modelBuilder.Entity("BranchDestinationRegion", b =>
+                {
+                    b.HasOne("CMetalsWS.Data.Branch", null)
+                        .WithMany()
+                        .HasForeignKey("BranchesId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("CMetalsWS.Data.DestinationRegion", null)
+                        .WithMany()
+                        .HasForeignKey("DestinationRegionsId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
                 });
 
             modelBuilder.Entity("CMetalsWS.Data.ApplicationUser", b =>

--- a/Services/CustomerService.cs
+++ b/Services/CustomerService.cs
@@ -114,6 +114,17 @@ namespace CMetalsWS.Services
             await db.SaveChangesAsync();
         }
 
+        public async Task DeleteCustomerAsync(int customerId)
+        {
+            using var db = _dbContextFactory.CreateDbContext();
+            var customer = await db.Customers.FindAsync(customerId);
+            if (customer != null)
+            {
+                db.Customers.Remove(customer);
+                await db.SaveChangesAsync();
+            }
+        }
+
         public async Task CreateCustomerAsync(Customer customer)
         {
             using var db = _dbContextFactory.CreateDbContext();

--- a/Services/DestinationRegionService.cs
+++ b/Services/DestinationRegionService.cs
@@ -1,6 +1,7 @@
 using CMetalsWS.Data;
 using Microsoft.EntityFrameworkCore;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace CMetalsWS.Services
@@ -17,27 +18,35 @@ namespace CMetalsWS.Services
         public async Task<List<DestinationRegion>> GetDestinationRegionsAsync()
         {
             using var db = _dbContextFactory.CreateDbContext();
-            return await db.DestinationRegions.ToListAsync();
+            return await db.DestinationRegions.Include(dr => dr.Branches).ToListAsync();
         }
 
         public async Task<DestinationRegion?> GetByIdAsync(int id)
         {
             using var db = _dbContextFactory.CreateDbContext();
-            return await db.DestinationRegions.FindAsync(id);
+            return await db.DestinationRegions.Include(dr => dr.Branches).FirstOrDefaultAsync(dr => dr.Id == id);
         }
 
-        public async Task CreateAsync(DestinationRegion destinationRegion)
+        public async Task CreateAsync(DestinationRegion destinationRegion, IEnumerable<int> branchIds)
         {
             using var db = _dbContextFactory.CreateDbContext();
+            var branches = await db.Branches.Where(b => branchIds.Contains(b.Id)).ToListAsync();
+            destinationRegion.Branches = branches;
             db.DestinationRegions.Add(destinationRegion);
             await db.SaveChangesAsync();
         }
 
-        public async Task UpdateAsync(DestinationRegion destinationRegion)
+        public async Task UpdateAsync(DestinationRegion destinationRegion, IEnumerable<int> branchIds)
         {
             using var db = _dbContextFactory.CreateDbContext();
-            db.Entry(destinationRegion).State = EntityState.Modified;
-            await db.SaveChangesAsync();
+            var regionToUpdate = await db.DestinationRegions.Include(dr => dr.Branches).FirstOrDefaultAsync(dr => dr.Id == destinationRegion.Id);
+            if (regionToUpdate != null)
+            {
+                regionToUpdate.Name = destinationRegion.Name;
+                var branches = await db.Branches.Where(b => branchIds.Contains(b.Id)).ToListAsync();
+                regionToUpdate.Branches = branches;
+                await db.SaveChangesAsync();
+            }
         }
 
         public async Task DeleteAsync(int id)

--- a/Services/IdentityDataSeeder.cs
+++ b/Services/IdentityDataSeeder.cs
@@ -58,12 +58,12 @@ namespace CMetalsWS.Services
             var supervisorPermissions = plannerPermissions.Concat(new[]
             {
                 Permissions.WorkOrders.Approve,
-                Permissions.PickingLists.Dispatch
+                Permissions.PickingLists.Dispatch,
+                Permissions.Customers.Add
             }).Distinct().ToArray();
 
             var managerPermissions = supervisorPermissions.Concat(new[]
             {
-                Permissions.Customers.Add, Permissions.Customers.Delete, Permissions.Customers.Import,
                 Permissions.Users.View,
                 Permissions.Roles.View,
                 Permissions.Branches.Edit,


### PR DESCRIPTION
This commit refactors the load planning feature to be dynamic based on user-configurable destination regions.

- Implemented a many-to-many relationship between DestinationRegion and Branch.
- Updated the Destination Regions management page to allow assigning a region to one or more branches.
- Made the "Load Planning" section in the main navigation menu dynamic, populating it with an entry for each configured DestinationRegion.
- Created a single, new load planning page that replaces the three old ones. This new page is parameterized by DestinationRegionId and displays the relevant picking lists for the selected region.