### PR TITLE
fix: Preserve SA_PASSWORD when running docker compose via sudo

### DIFF
--- a/bootstrap-ubuntu.sh
+++ b/bootstrap-ubuntu.sh
@@ -149,8 +149,8 @@ export SA_PASSWORD
 
 echo "==> Building and starting SQL Server"
 # The .env file is now available for compose variable substitution
-sudo docker compose -f docker-compose.sql.yml build --pull
-sudo docker compose -f docker-compose.sql.yml up -d
+sudo --preserve-env=SA_PASSWORD docker compose -f docker-compose.sql.yml build --pull
+sudo --preserve-env=SA_PASSWORD docker compose -f docker-compose.sql.yml up -d
 
 echo "==> Waiting for cmetalsws-sql to be healthy…"
 for i in {1..30}; do


### PR DESCRIPTION
The `bootstrap-ubuntu.sh` script uses `sudo` to run `docker compose`, which sanitizes the environment and removes the `SA_PASSWORD` variable if it was provided via the shell. This causes the SQL Server container to start with a default password, leading to a connection failure with the application which is configured with the shell-provided password.

This change adds the `--preserve-env=SA_PASSWORD` flag to the `sudo` command when calling `docker compose`. This ensures that the `SA_PASSWORD` environment variable is passed through to `docker compose`, allowing it to be used for the container configuration and preventing the password mismatch.