### PR TITLE
feat: Enhance coil to sheet relationship features

### DIFF
--- a/Components/Layout/NavMenu.razor
+++ b/Components/Layout/NavMenu.razor
@@ -60,6 +60,7 @@
                     <MudNavLink Href="/operations/pulling/sheet-queue" Icon="@Icons.Material.Filled.ViewList">Sheet Pulling Queue</MudNavLink>
                 }
                 <MudNavLink Href="/operations/item-relations" Icon="@Icons.Material.Filled.Link">Item Relationships</MudNavLink>
+                <MudNavLink Href="/operations/import-item-relations" Icon="@Icons.Material.Filled.UploadFile">Import Relationships</MudNavLink>
             }
         </MudNavGroup>
     }

--- a/Components/Pages/Operations/ImportItemRelations.razor
+++ b/Components/Pages/Operations/ImportItemRelations.razor
@@ -1,0 +1,87 @@
+@page "/operations/import-item-relations"
+@using CMetalsWS.Services
+@using System.IO
+@using Microsoft.AspNetCore.Components.Forms
+@inject ItemRelationshipService RelService
+@inject ISnackbar Snackbar
+
+<PageTitle>Import Item Relationships</PageTitle>
+
+<MudPaper Class="p-4">
+    <MudStack Spacing="2">
+        <MudText Typo="Typo.h5">Import Coil → Sheet Relationships</MudText>
+        <MudText>Select an Excel file with the following columns: <strong>ItemCode</strong>, <strong>Description</strong>, <strong>CoilRelationship</strong>.</MudText>
+
+        <InputFile OnChange="OnFileChanged" accept=".xlsx,.xls" />
+
+        @if (_file != null)
+        {
+            <MudText>File: @_file.Name</MudText>
+        }
+
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="ImportAsync" Disabled="_isUploading || _file == null">Import</MudButton>
+
+        @if (_importResult != null)
+        {
+            <MudCard Class="mt-4">
+                <MudCardHeader><CardHeaderContent><MudText Typo="Typo.h6">Import Results</MudText></CardHeaderContent></MudCardHeader>
+                <MudCardContent>
+                    <MudText>Total Rows: @_importResult.TotalRows</MudText>
+                    <MudText>Successful Imports: @_importResult.SuccessfulImports</MudText>
+                    <MudText>Failed Imports: @_importResult.FailedImports</MudText>
+                    @if (_importResult.Errors.Any())
+                    {
+                        <MudText Typo="Typo.subtitle1" Class="mt-2">Errors:</MudText>
+                        <MudList>
+                            @foreach (var error in _importResult.Errors)
+                            {
+                                <MudListItem>@error</MudListItem>
+                            }
+                        </MudList>
+                    }
+                </MudCardContent>
+            </MudCard>
+        }
+    </MudStack>
+</MudPaper>
+
+@code {
+    private IBrowserFile? _file;
+    private bool _isUploading;
+    private ImportResult? _importResult;
+
+    private void OnFileChanged(InputFileChangeEventArgs e)
+    {
+        _file = e.File;
+        _importResult = null;
+    }
+
+    private async Task ImportAsync()
+    {
+        if (_file == null)
+        {
+            Snackbar.Add("Please select a file.", Severity.Warning);
+            return;
+        }
+
+        _isUploading = true;
+        _importResult = null;
+        StateHasChanged();
+
+        try
+        {
+            await using var stream = _file.OpenReadStream(maxAllowedSize: 10_000_000); // 10 MB limit
+            _importResult = await RelService.ImportFromExcelAsync(stream);
+            Snackbar.Add("Import completed.", Severity.Success);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Import failed: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _isUploading = false;
+            StateHasChanged();
+        }
+    }
+}

--- a/Components/Pages/Operations/Pickinglist/PickingListDialog.razor
+++ b/Components/Pages/Operations/Pickinglist/PickingListDialog.razor
@@ -6,6 +6,7 @@
 @inject ISnackbar Snackbar
 @inject CustomerService CustomerService
 @inject PickingListService PickingListService
+@inject ItemRelationshipService RelService
 
 <MudDialog>
     <TitleContent>
@@ -105,7 +106,15 @@
                     </HeaderContent>
                     <RowTemplate>
                         <MudTd DataLabel="Line">@context.LineNumber</MudTd>
-                        <MudTd DataLabel="Item">@context.ItemId</MudTd>
+                        <MudTd DataLabel="Item">
+                            @context.ItemId
+                            @if (_parentLookup.TryGetValue(context.ItemId, out var parentRel))
+                            {
+                                <MudTooltip Text="@($"Coil: {parentRel.ParentItemId} - {parentRel.ParentItemDescription}")">
+                                    <MudIcon Icon="@Icons.Material.Filled.Info" Color="Color.Primary" Size="Size.Small" Class="ml-1" />
+                                </MudTooltip>
+                            }
+                        </MudTd>
                         <MudTd DataLabel="Description">@context.ItemDescription</MudTd>
                         <MudTd DataLabel="Qty" Class="text-right">@context.Quantity.ToString("N3")</MudTd>
                         <MudTd DataLabel="Unit">@context.Unit</MudTd>
@@ -181,6 +190,7 @@
 
     private Customer? _selectedCustomer;
     private bool CanAddOrEdit => IsEdit || (Model?.Id ?? 0) == 0;
+    private Dictionary<string, ItemRelationship> _parentLookup = new();
 
     protected override async Task OnParametersSetAsync()
     {
@@ -191,6 +201,15 @@
 
         if (Model.CustomerId.HasValue && _selectedCustomer == null)
             _selectedCustomer = await CustomerService.GetByIdAsync(Model.CustomerId.Value);
+
+        if (Model.Items != null && Model.Items.Any())
+        {
+            var itemIds = Model.Items.Select(i => i.ItemId).ToList();
+            if (itemIds.Any())
+            {
+                _parentLookup = await RelService.GetParentsForChildrenAsync(itemIds);
+            }
+        }
     }
 
 

--- a/Components/Pages/Operations/WorkOrder/WorkOrderDialog.razor
+++ b/Components/Pages/Operations/WorkOrder/WorkOrderDialog.razor
@@ -281,12 +281,33 @@
 
         try
         {
-            _parentItem = await InvService.GetByTagNumberAsync(Model.TagNumber);
-            if (_parentItem is null)
+            var item = await InvService.GetByTagNumberAsync(Model.TagNumber);
+            if (item is null)
             {
                 Snackbar.Add($"Tag '{Model.TagNumber}' not found.", Severity.Error);
                 return;
             }
+
+            // Check if the scanned item is a child sheet
+            var parentRel = await RelService.GetParentAsync(item.ItemId);
+            if (parentRel != null)
+            {
+                // It's a sheet, so find the actual parent coil
+                var parents = await InvService.GetByItemIdsAsync(new List<string> { parentRel.ParentItemId });
+                _parentItem = parents.FirstOrDefault();
+            }
+            else
+            {
+                // It's a coil
+                _parentItem = item;
+            }
+
+            if (_parentItem is null)
+            {
+                Snackbar.Add("Could not determine the parent coil for the scanned tag.", Severity.Error);
+                return;
+            }
+
             Model.ParentItemId = _parentItem.ItemId;
 
             if (Model.MachineCategory == MachineCategory.Slitter)
@@ -300,11 +321,13 @@
                 if (children.Count == 0)
                 {
                     Snackbar.Add($"No child items (sheets) are related to the coil with tag '{Model.TagNumber}'. Use the 'Item Relationships' page to add some.", Severity.Info);
-                    return;
+                    _childItems.Clear();
                 }
-
-                _childItems.Clear();
-                _childItems = children.Select(c => new InventoryItem { ItemId = c.ChildItemId, Description = c.ChildItemDescription }).ToList();
+                else
+                {
+                    _childItems.Clear();
+                    _childItems = children.Select(c => new InventoryItem { ItemId = c.ChildItemId, Description = c.ChildItemDescription }).ToList();
+                }
             }
             Snackbar.Add($"Found {_childItems.Count} potential child item(s).", Severity.Success);
             StateHasChanged();


### PR DESCRIPTION
This commit introduces several enhancements to the coil-to-sheet item relationship functionality.

- Adds a new page to import coil-to-sheet relationships from an Excel file. The importer uses the MiniExcel library for efficient parsing and provides feedback on the import process.
- Enhances the Work Order creation dialog. The tag search now correctly identifies sheets, finds their parent coil, and loads the relevant items for the work order.
- Improves the Picking List dialog by displaying a tooltip with the parent coil's information for any line item that is a sheet.
- Adds a link to the new import page in the main navigation menu.