### PR TITLE
feat: Implement SignalR for real-time pulling schedule updates

### DIFF
--- a/Components/Pages/Operations/SheetPullingQueue.razor
+++ b/Components/Pages/Operations/SheetPullingQueue.razor
@@ -6,6 +6,7 @@
 @using Microsoft.AspNetCore.Components.Authorization
 @using CMetalsWS.Components.Pages.Operations.Pickinglist.Dialogs
 @using Microsoft.AspNetCore.Identity
+@using Microsoft.AspNetCore.SignalR.Client
 @attribute [Authorize(Policy = Permissions.PickingLists.Assign)]
 
 @inject PickingListService PickingListService
@@ -15,6 +16,9 @@
 @inject IDialogService DialogService
 @inject UserService UserService
 @inject UserManager<ApplicationUser> UserManager
+@inject NavigationManager NavigationManager
+
+@implements IAsyncDisposable
 
 <MudText Typo="Typo.h5" Class="mb-4">Sheet Pulling Queue</MudText>
 
@@ -62,6 +66,7 @@
     private List<PickingListItem> _tasks = new();
     private Dictionary<int, AuditEventType?> _auditEvents = new();
     private ApplicationUser? _user;
+    private HubConnection? _hubConnection;
 
     protected override async Task OnInitializedAsync()
     {
@@ -71,6 +76,26 @@
         {
             _user = await UserManager.GetUserAsync(user);
             await LoadTasks();
+        }
+
+        _hubConnection = new HubConnectionBuilder()
+            .WithUrl(NavigationManager.ToAbsoluteUri("/hubs/schedule"))
+            .Build();
+
+        _hubConnection.On<int>("PickingListUpdated", async (id) =>
+        {
+            await LoadTasks();
+            await InvokeAsync(StateHasChanged);
+        });
+
+        await _hubConnection.StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_hubConnection is not null)
+        {
+            await _hubConnection.DisposeAsync();
         }
     }
 

--- a/Components/Pages/Schedule/PullingSchedule.razor
+++ b/Components/Pages/Schedule/PullingSchedule.razor
@@ -208,11 +208,6 @@
 
         Snackbar.Add($"Moved {listToMove.SalesOrderNumber} to machine {_machines.FirstOrDefault(m => m.Id == newMachineId)?.Name} on {newDate:ddd, MMM dd}", Severity.Success);
 
-        if (_hub is not null)
-        {
-            await _hub.SendAsync("PickingListUpdated", listToMove.Id);
-        }
-
         StateHasChanged();
     }
 


### PR DESCRIPTION
This commit introduces SignalR functionality to provide real-time updates to the sheet pulling queue.

- Modified `PickingListService` to inject `IHubContext<ScheduleHub>` and send a `PickingListUpdated` message after reordering the pulling queue. This ensures notifications are sent only after data is persisted.
- Updated `SheetPullingQueue.razor` to connect to the `ScheduleHub`, listen for `PickingListUpdated` messages, and refresh its data in real-time.
- Changed the sorting logic in `PickingListService.GetSheetPullingQueueAsync` to order by `ScheduledProcessingDate` and then `Priority` as per requirements.
- Cleaned up `PullingSchedule.razor` by removing the client-side hub invocation, centralizing the notification logic in the service layer.
- Simplified `ScheduleHub.cs` by removing the now-redundant `PickingListUpdated` method.