### PR TITLE
Fix(PickingList): Correct equality check for new picking list items

### DIFF
--- a/Data/Pickinglist.cs
+++ b/Data/Pickinglist.cs
@@ -114,10 +114,27 @@ namespace CMetalsWS.Data
         {
             if (other is null) return false;
             if (ReferenceEquals(this, other)) return true;
+
+            // For new entities, Id is 0. Use LineNumber for equality as it's unique within the list.
+            if (Id == 0 && other.Id == 0)
+            {
+                return PickingListId == other.PickingListId && LineNumber == other.LineNumber;
+            }
+
             return Id == other.Id;
         }
 
         public override bool Equals(object? obj) => Equals(obj as PickingListItem);
-        public override int GetHashCode() => Id.GetHashCode();
+
+        public override int GetHashCode()
+        {
+            // For new entities, Id is 0. Use LineNumber for hash code.
+            if (Id == 0)
+            {
+                return HashCode.Combine(PickingListId, LineNumber);
+            }
+
+            return Id.GetHashCode();
+        }
     }
 }


### PR DESCRIPTION
The bulk machine assignment feature was not working correctly because the `HashSet` used for multi-selection was only storing one item. This was caused by the `Equals` and `GetHashCode` methods on `PickingListItem`, which relied solely on the `Id` property.

For new items parsed from a PDF, the `Id` is 0, causing all new items to be treated as duplicates by the `HashSet`.

This commit updates the `Equals` and `GetHashCode` methods to use `PickingListId` and `LineNumber` for equality comparison when the `Id` is 0. This ensures that new, unsaved items are correctly distinguished, allowing the multi-select and bulk assignment features to function as intended.