### PR TITLE
feat: Add permanent filter to PickingAndPacking

### DIFF
--- a/Components/Pages/Operations/PickingAndPacking.razor
+++ b/Components/Pages/Operations/PickingAndPacking.razor
@@ -58,8 +58,8 @@
                         <MudText Typo="Typo.body2">@pickingList.Customer?.CustomerName</MudText>
                     </CardHeaderContent>
                     <CardHeaderActions>
-                        <MudChip T="string" Color="@(GetPriorityColor(pickingList.Priority))" Value="@GetPriorityText(pickingList.Priority)">@GetPriorityText(pickingList.Priority)</MudChip>
-                        <MudChip T="string" Color="Color.Default" Value="@pickingList.Status.ToString()">@pickingList.Status.ToString()</MudChip>
+                        <MudChip T="string" Color="@(GetPriorityColor(pickingList.Priority))">@GetPriorityText(pickingList.Priority)</MudChip>
+                        <MudChip T="string" Color="Color.Default">@pickingList.Status.ToString()</MudChip>
                     </CardHeaderActions>
                 </MudCardHeader>
                 <MudCardContent>
@@ -97,8 +97,8 @@
                         <MudText Typo="Typo.body2">@pickingList.Customer?.CustomerName • @pickingList.Branch?.Name • @pickingList.DestinationRegion?.Name</MudText>
                     </div>
                     <div>
-                        <MudChip T="string" Color="Color.Warning" Value="'Picking'">Picking</MudChip>
-                        <MudChip T="string" Color="@(GetPriorityColor(pickingList.Priority))" Class="ml-2" Value="@GetPriorityText(pickingList.Priority)">@GetPriorityText(pickingList.Priority)</MudChip>
+                        <MudChip T="string" Color="@(GetStatusColor(pickingList.Status))">@pickingList.Status.ToString()</MudChip>
+                        <MudChip T="string" Color="@(GetPriorityColor(pickingList.Priority))" Class="ml-2">@GetPriorityText(pickingList.Priority)</MudChip>
                     </div>
                 </div>
 
@@ -135,14 +135,23 @@
                             }
                         </div>
                         <div>
-                            @if (item.Picked)
-                            {
-                                <MudButton Variant="Variant.Outlined">Details</MudButton>
-                            }
-                            else
+                            @if (item.Status == PickingLineStatus.Pending && !item.Picked)
                             {
                                 <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.QrCodeScanner" Class="mr-2">Scan</MudButton>
-                                <MudButton Variant="Variant.Filled" Color="Color.Success" OnClick="@(() => CompletePick(item))">Start Pick</MudButton>
+                                <MudButton Variant="Variant.Filled" Color="Color.Success" OnClick="@(() => StartPickTask(item))">Start Pick</MudButton>
+                            }
+                            else if (item.Status == PickingLineStatus.InProgress)
+                            {
+                                <MudButton Variant="Variant.Filled" Color="Color.Warning" OnClick="@(() => PausePick(item))">Pause</MudButton>
+                                <MudButton Variant="Variant.Filled" Color="Color.Success" OnClick="@(() => CompletePick(item))" Class="ml-2">Complete</MudButton>
+                            }
+                            else if (item.Status == PickingLineStatus.Paused)
+                            {
+                                <MudButton Variant="Variant.Filled" Color="Color.Info" OnClick="@(() => ResumePick(item))">Resume</MudButton>
+                            }
+                            else if (item.Status == PickingLineStatus.Picked || item.Picked)
+                            {
+                                <MudChip T="string" Icon="@Icons.Material.Filled.Check" Color="Color.Success">Picked</MudChip>
                             }
                         </div>
                     </MudPaper>
@@ -156,7 +165,7 @@
         }
     </MudTabPanel>
     <MudTabPanel Text="Packing Process">
-        @foreach (var pickingList in FilteredPickingLists.Where(pl => pl.Items.Any(i => i.Picked)))
+        @foreach (var pickingList in FilteredPickingLists.Where(pl => pl.Status == PickingListStatus.Picked || pl.Status == PickingListStatus.InProgress))
         {
             <MudPaper Class="pa-4 rounded-lg mb-4">
                 <div class="d-flex justify-space-between align-center">
@@ -168,8 +177,8 @@
                         <MudText Typo="Typo.body2">@pickingList.Customer?.CustomerName • @pickingList.Branch?.Name • @pickingList.DestinationRegion?.Name</MudText>
                     </div>
                     <div>
-                        <MudChip T="string" Color="Color.Info" Value="'Packing'">Packing</MudChip>
-                        <MudChip T="string" Color="@(GetPriorityColor(pickingList.Priority))" Class="ml-2" Value="@GetPriorityText(pickingList.Priority)">@GetPriorityText(pickingList.Priority)</MudChip>
+                        <MudChip T="string" Color="@(GetStatusColor(pickingList.Status))">@pickingList.Status.ToString()</MudChip>
+                        <MudChip T="string" Color="@(GetPriorityColor(pickingList.Priority))" Class="ml-2">@GetPriorityText(pickingList.Priority)</MudChip>
                     </div>
                 </div>
 
@@ -177,7 +186,7 @@
                     <div class="d-flex justify-space-between align-center">
                         <div>
                             <MudText Typo="Typo.h6">Packing Progress</MudText>
-                            <MudText Typo="Typo.body2">@GetPackedItemsCount(pickingList) of @pickingList.Items.Count(i => i.Picked) items packed</MudText>
+                            <MudText Typo="Typo.body2">@GetPackedItemsCount(pickingList) of @pickingList.Items.Count items packed</MudText>
                         </div>
                         <div style="width: 200px;">
                             <MudProgressLinear Color="Color.Info" Value="@GetPackingProgress(pickingList)" />
@@ -199,21 +208,30 @@
                             </div>
                             @if (item.Packed)
                             {
-                                <div class="d-flex align-center mt-2" style="color: #1976D2;">
+                                <div class="d-flex align-center mt-2" style="color: #0D47A1;">
                                     <MudIcon Icon="@Icons.Material.Filled.CheckCircle" Class="mr-1" />
                                     <MudText Typo="Typo.body2">Packed by @item.PackedBy?.UserName at @item.PackedAt?.ToShortTimeString()</MudText>
                                 </div>
                             }
                         </div>
                         <div>
-                            @if (item.Packed)
-                            {
-                                <MudButton Variant="Variant.Outlined">Details</MudButton>
-                            }
-                            else
+                            @if (item.Status == PickingLineStatus.Picked && !item.Packed)
                             {
                                 <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.QrCodeScanner" Class="mr-2">Scan</MudButton>
-                                <MudButton Variant="Variant.Filled" Color="Color.Info" OnClick="@(() => CompletePack(item))">Start Pack</MudButton>
+                                <MudButton Variant="Variant.Filled" Color="Color.Info" OnClick="@(() => StartPackTask(item))">Start Pack</MudButton>
+                            }
+                            else if (item.Status == PickingLineStatus.InProgress)
+                            {
+                                <MudButton Variant="Variant.Filled" Color="Color.Warning" OnClick="@(() => PausePack(item))">Pause</MudButton>
+                                <MudButton Variant="Variant.Filled" Color="Color.Success" OnClick="@(() => CompletePack(item))" Class="ml-2">Complete</MudButton>
+                            }
+                            else if (item.Status == PickingLineStatus.Paused)
+                            {
+                                <MudButton Variant="Variant.Filled" Color="Color.Info" OnClick="@(() => ResumePack(item))">Resume</MudButton>
+                            }
+                            else if (item.Status == PickingLineStatus.Packed || item.Packed)
+                            {
+                                <MudChip T="string" Icon="@Icons.Material.Filled.Check" Color="Color.Success">Packed</MudChip>
                             }
                         </div>
                     </MudPaper>
@@ -325,6 +343,19 @@
         };
     }
 
+    private MudBlazor.Color GetStatusColor(PickingListStatus status)
+    {
+        return status switch
+        {
+            PickingListStatus.Pending => MudBlazor.Color.Default,
+            PickingListStatus.InProgress => MudBlazor.Color.Warning,
+            PickingListStatus.OnHold => MudBlazor.Color.Info,
+            PickingListStatus.Picked => MudBlazor.Color.Success,
+            PickingListStatus.Completed => MudBlazor.Color.Primary,
+            _ => MudBlazor.Color.Default
+        };
+    }
+
     private async Task LoadData()
     {
         _pickingLists = await PickingListService.GetAsync();
@@ -371,16 +402,9 @@
 
     private async Task CompletePack(PickingListItem item)
     {
-        // This now acts as the 'Complete' button's action
-        var parameters = new DialogParameters { ["Item"] = item };
-        var dialog = await DialogService.ShowAsync<PackItemDialog>("Pack Item", parameters);
-        var result = await dialog.Result;
-
-        if (result is not null && !result.Canceled && result.Data is PackItemDialog.PackDialogResult packResult)
-        {
-            await PickingListService.ConfirmPackAsync(item.Id, _userId!, packResult.Quantity, packResult.ActualWeight, packResult.Notes);
-            await LoadData();
-        }
+        // This now acts as the 'Complete' button's action, bypassing the dialog
+        await PickingListService.ConfirmPackAsync(item.Id, _userId!, item.Quantity, item.Weight ?? 0, "");
+        await LoadData();
     }
 
     private async Task PausePack(PickingListItem item)
@@ -395,15 +419,27 @@
         await LoadData();
     }
 
-    private int GetPackedItemsCount(PickingList pickingList)
+    private async Task PauseList(PickingList pickingList)
     {
-        return pickingList.Items.Count(i => i.Packed);
+        await PickingListService.PauseListAsync(pickingList.Id, _userId!);
+        await LoadData();
+    }
+
+    private async Task CompletePicking(PickingList pickingList)
+    {
+        await PickingListService.CompletePickingAsync(pickingList.Id, _userId!);
+        await LoadData();
     }
 
     private async Task CompletePacking(PickingList pickingList)
     {
         await PickingListService.CompletePackingAsync(pickingList.Id, _userId!);
         await LoadData();
+    }
+
+    private int GetPackedItemsCount(PickingList pickingList)
+    {
+        return pickingList.Items.Count(i => i.Packed);
     }
 
     private int GetTotalLineItems(PickingList pickingList)
@@ -415,6 +451,7 @@
     {
         return pickingList.Items.Where(i => i.Machine != null && (i.Machine.Category == MachineCategory.Sheet || i.Machine.Category == MachineCategory.Coil)).Sum(i => i.Weight ?? 0);
     }
+
     private double GetPickingProgress(PickingList pickingList)
     {
         if (pickingList.Items == null || !pickingList.Items.Any())

--- a/Components/Pages/Operations/PickingAndPacking.razor
+++ b/Components/Pages/Operations/PickingAndPacking.razor
@@ -442,6 +442,11 @@
         return pickingList.Items.Count(i => i.Packed);
     }
 
+    private int GetPickedItemsCount(PickingList pickingList)
+    {
+        return pickingList.Items.Count(i => i.Picked);
+    }
+
     private int GetTotalLineItems(PickingList pickingList)
     {
         return pickingList.Items.Count(i => i.Machine != null && (i.Machine.Category == MachineCategory.Sheet || i.Machine.Category == MachineCategory.Coil));

--- a/Components/Pages/Operations/PickingAndPacking.razor
+++ b/Components/Pages/Operations/PickingAndPacking.razor
@@ -87,97 +87,143 @@
     <MudTabPanel Text="Picking Process">
         @foreach (var pickingList in FilteredPickingLists.Where(pl => pl.Status == PickingListStatus.Pending || pl.Status == PickingListStatus.InProgress))
         {
-            <MudCard Class="mb-4">
-                <MudCardHeader>
-                    <CardHeaderContent>
-                        <MudText Typo="Typo.h6">@pickingList.SalesOrderNumber - Picking</MudText>
-                        <MudText Typo="Typo.body2">@pickingList.Customer?.CustomerName</MudText>
-                    </CardHeaderContent>
-                    <CardHeaderActions>
-                        <MudChip T="string" Color="@(GetPriorityColor(pickingList.Priority))" Value="@GetPriorityText(pickingList.Priority)">@GetPriorityText(pickingList.Priority)</MudChip>
-                        <MudChip T="string" Color="Color.Default" Value="@pickingList.Status.ToString()">@pickingList.Status.ToString()</MudChip>
-                    </CardHeaderActions>
-                </MudCardHeader>
-                <MudCardContent>
-                    @foreach (var item in pickingList.Items.Where(i => i.Machine != null && (i.Machine.Category == MachineCategory.Sheet || i.Machine.Category == MachineCategory.Coil)))
-                    {
-                        <MudPaper Class="d-flex align-center pa-2 mb-2">
-                            <div class="flex-grow-1">
-                                <MudText>@item.ItemDescription</MudText>
-                                <MudText Typo="Typo.body2">@item.Width" x @item.Length"</MudText>
-                                <MudText Typo="Typo.body2">Qty: @item.Quantity, Weight: @item.Weight</MudText>
+            <MudPaper Class="pa-4 rounded-lg mb-4">
+                <div class="d-flex justify-space-between align-center">
+                    <div>
+                        <div class="d-flex align-center">
+                            <MudIcon Icon="@Icons.Material.Filled.QrCode2" Class="mr-2" />
+                            <MudText Typo="Typo.h6">@pickingList.SalesOrderNumber - Picking Process</MudText>
+                        </div>
+                        <MudText Typo="Typo.body2">@pickingList.Customer?.CustomerName • @pickingList.Branch?.Name • @pickingList.DestinationRegion?.Name</MudText>
+                    </div>
+                    <div>
+                        <MudChip T="string" Color="Color.Warning" Value="'Picking'">Picking</MudChip>
+                        <MudChip T="string" Color="@(GetPriorityColor(pickingList.Priority))" Class="ml-2" Value="@GetPriorityText(pickingList.Priority)">@GetPriorityText(pickingList.Priority)</MudChip>
+                    </div>
+                </div>
+
+                <div class="mt-4 pa-4" style="background-color: #E8F5E9; border-radius: 8px;">
+                    <div class="d-flex justify-space-between align-center">
+                        <div>
+                            <MudText Typo="Typo.h6">Picking Progress</MudText>
+                            <MudText Typo="Typo.body2">@GetPickedItemsCount(pickingList) of @pickingList.Items.Count items picked</MudText>
+                        </div>
+                        <div style="width: 200px;">
+                            <MudProgressLinear Color="Color.Success" Value="@GetPickingProgress(pickingList)" />
+                        </div>
+                    </div>
+                </div>
+
+                @foreach (var item in pickingList.Items.Where(i => i.Machine != null && (i.Machine.Category == MachineCategory.Sheet || i.Machine.Category == MachineCategory.Coil)))
+                {
+                    <MudPaper Class="d-flex align-center pa-4 mt-4 rounded-lg" Elevation="0" Style="@(item.Picked ? "border: 1px solid #C8E6C9;" : "border: 1px solid #FFECB3;")">
+                        <div class="flex-grow-1">
+                            <MudText Typo="Typo.h6">@item.ItemDescription</MudText>
+                            <MudText Typo="Typo.body2">@item.Width" x @item.Length" • Qty: @item.Quantity • @item.Weight lbs</MudText>
+                            <div class="d-flex align-center mt-2">
+                                <MudIcon Icon="@Icons.Material.Filled.LocationOn" Class="mr-1" />
+                                <MudText Typo="Typo.body2">Location: @item.Machine?.Name</MudText>
+                                <MudIcon Icon="@Icons.Material.Filled.Layers" Class="ml-4 mr-1" />
+                                <MudText Typo="Typo.body2">Coil: @item.ItemId</MudText>
                             </div>
-                            <div>
-                                @if (item.Status == PickingLineStatus.Pending)
-                                {
-                                    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@(() => StartPickTask(item))" Disabled="@(ActivePickingListId != pickingList.Id)">Start Pick</MudButton>
-                                }
-                                else if (item.Status == PickingLineStatus.InProgress)
-                                {
-                                    <MudButton Variant="Variant.Filled" Color="Color.Warning" OnClick="@(() => PausePick(item))">Pause</MudButton>
-                                    <MudButton Variant="Variant.Filled" Color="Color.Success" OnClick="@(() => CompletePick(item))" Class="ml-2">Complete</MudButton>
-                                }
-                                else if (item.Status == PickingLineStatus.Paused)
-                                {
-                                    <MudButton Variant="Variant.Filled" Color="Color.Info" OnClick="@(() => ResumePick(item))">Resume</MudButton>
-                                }
-                                else if (item.Status == PickingLineStatus.Picked || item.Picked)
-                                {
-                                    <MudChip T="string" Icon="@Icons.Material.Filled.Check" Color="Color.Success">Picked</MudChip>
-                                }
-                            </div>
-                        </MudPaper>
-                    }
-                </MudCardContent>
-            </MudCard>
+                            @if (item.Picked)
+                            {
+                                <div class="d-flex align-center mt-2" style="color: #2E7D32;">
+                                    <MudIcon Icon="@Icons.Material.Filled.CheckCircle" Class="mr-1" />
+                                    <MudText Typo="Typo.body2">Picked by @item.PickedBy?.UserName at @item.PickedAt?.ToShortTimeString()</MudText>
+                                </div>
+                            }
+                        </div>
+                        <div>
+                            @if (item.Picked)
+                            {
+                                <MudButton Variant="Variant.Outlined">Details</MudButton>
+                            }
+                            else
+                            {
+                                <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.QrCodeScanner" Class="mr-2">Scan</MudButton>
+                                <MudButton Variant="Variant.Filled" Color="Color.Success" OnClick="@(() => CompletePick(item))">Start Pick</MudButton>
+                            }
+                        </div>
+                    </MudPaper>
+                }
+                <div class="d-flex justify-end mt-4">
+                    <MudText Typo="Typo.body1" Class="mr-4">Total Weight: @GetTotalWeight(pickingList).ToString("N2") lbs</MudText>
+                    <MudButton Variant="Variant.Outlined" OnClick="@(() => PauseList(pickingList))" Class="mr-2">Pause List</MudButton>
+                    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@(() => CompletePicking(pickingList))">Complete Picking</MudButton>
+                </div>
+            </MudPaper>
         }
     </MudTabPanel>
     <MudTabPanel Text="Packing Process">
         @foreach (var pickingList in FilteredPickingLists.Where(pl => pl.Items.Any(i => i.Picked)))
         {
-            <MudCard Class="mb-4">
-                <MudCardHeader>
-                    <CardHeaderContent>
-                        <MudText Typo="Typo.h6">@pickingList.SalesOrderNumber - Packing</MudText>
-                        <MudText Typo="Typo.body2">@pickingList.Customer?.CustomerName</MudText>
-                    </CardHeaderContent>
-                    <CardHeaderActions>
-                        <MudChip T="string" Color="@(GetPriorityColor(pickingList.Priority))" Value="@GetPriorityText(pickingList.Priority)">@GetPriorityText(pickingList.Priority)</MudChip>
-                        <MudChip T="string" Color="Color.Default" Value="@pickingList.Status.ToString()">@pickingList.Status.ToString()</MudChip>
-                    </CardHeaderActions>
-                </MudCardHeader>
-                <MudCardContent>
-                    @foreach (var item in pickingList.Items.Where(i => i.Picked && i.Machine != null && (i.Machine.Category == MachineCategory.Sheet || i.Machine.Category == MachineCategory.Coil)))
-                    {
-                        <MudPaper Class="d-flex align-center pa-2 mb-2">
-                            <div class="flex-grow-1">
-                                <MudText>@item.ItemDescription</MudText>
-                                <MudText Typo="Typo.body2">@item.Width" x @item.Length"</MudText>
-                                <MudText Typo="Typo.body2">Qty: @item.Quantity, Weight: @item.Weight</MudText>
+            <MudPaper Class="pa-4 rounded-lg mb-4">
+                <div class="d-flex justify-space-between align-center">
+                    <div>
+                        <div class="d-flex align-center">
+                            <MudIcon Icon="@Icons.Material.Filled.QrCode2" Class="mr-2" />
+                            <MudText Typo="Typo.h6">@pickingList.SalesOrderNumber - Packing Process</MudText>
+                        </div>
+                        <MudText Typo="Typo.body2">@pickingList.Customer?.CustomerName • @pickingList.Branch?.Name • @pickingList.DestinationRegion?.Name</MudText>
+                    </div>
+                    <div>
+                        <MudChip T="string" Color="Color.Info" Value="'Packing'">Packing</MudChip>
+                        <MudChip T="string" Color="@(GetPriorityColor(pickingList.Priority))" Class="ml-2" Value="@GetPriorityText(pickingList.Priority)">@GetPriorityText(pickingList.Priority)</MudChip>
+                    </div>
+                </div>
+
+                <div class="mt-4 pa-4" style="background-color: #E3F2FD; border-radius: 8px;">
+                    <div class="d-flex justify-space-between align-center">
+                        <div>
+                            <MudText Typo="Typo.h6">Packing Progress</MudText>
+                            <MudText Typo="Typo.body2">@GetPackedItemsCount(pickingList) of @pickingList.Items.Count(i => i.Picked) items packed</MudText>
+                        </div>
+                        <div style="width: 200px;">
+                            <MudProgressLinear Color="Color.Info" Value="@GetPackingProgress(pickingList)" />
+                        </div>
+                    </div>
+                </div>
+
+                @foreach (var item in pickingList.Items.Where(i => i.Picked && i.Machine != null && (i.Machine.Category == MachineCategory.Sheet || i.Machine.Category == MachineCategory.Coil)))
+                {
+                    <MudPaper Class="d-flex align-center pa-4 mt-4 rounded-lg" Elevation="0" Style="@(item.Packed ? "border: 1px solid #BBDEFB;" : "border: 1px solid #FFECB3;")">
+                        <div class="flex-grow-1">
+                            <MudText Typo="Typo.h6">@item.ItemDescription</MudText>
+                            <MudText Typo="Typo.body2">@item.Width" x @item.Length" • Qty: @item.Quantity • @item.Weight lbs</MudText>
+                            <div class="d-flex align-center mt-2">
+                                <MudIcon Icon="@Icons.Material.Filled.LocationOn" Class="mr-1" />
+                                <MudText Typo="Typo.body2">Location: @item.Machine?.Name</MudText>
+                                <MudIcon Icon="@Icons.Material.Filled.Layers" Class="ml-4 mr-1" />
+                                <MudText Typo="Typo.body2">Coil: @item.ItemId</MudText>
                             </div>
-                            <div>
-                                @if (item.Status == PickingLineStatus.Picked && !item.Packed)
-                                {
-                                    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@(() => StartPackTask(item))" Disabled="@(ActivePickingListId != pickingList.Id)">Start Pack</MudButton>
-                                }
-                                else if (item.Status == PickingLineStatus.InProgress)
-                                {
-                                    <MudButton Variant="Variant.Filled" Color="Color.Warning" OnClick="@(() => PausePack(item))">Pause</MudButton>
-                                    <MudButton Variant="Variant.Filled" Color="Color.Success" OnClick="@(() => CompletePack(item))" Class="ml-2">Complete</MudButton>
-                                }
-                                else if (item.Status == PickingLineStatus.Paused)
-                                {
-                                    <MudButton Variant="Variant.Filled" Color="Color.Info" OnClick="@(() => ResumePack(item))">Resume</MudButton>
-                                }
-                                else if (item.Status == PickingLineStatus.Packed || item.Packed)
-                                {
-                                    <MudChip T="string" Icon="@Icons.Material.Filled.Check" Color="Color.Success">Packed</MudChip>
-                                }
-                            </div>
-                        </MudPaper>
-                    }
-                </MudCardContent>
-            </MudCard>
+                            @if (item.Packed)
+                            {
+                                <div class="d-flex align-center mt-2" style="color: #1976D2;">
+                                    <MudIcon Icon="@Icons.Material.Filled.CheckCircle" Class="mr-1" />
+                                    <MudText Typo="Typo.body2">Packed by @item.PackedBy?.UserName at @item.PackedAt?.ToShortTimeString()</MudText>
+                                </div>
+                            }
+                        </div>
+                        <div>
+                            @if (item.Packed)
+                            {
+                                <MudButton Variant="Variant.Outlined">Details</MudButton>
+                            }
+                            else
+                            {
+                                <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.QrCodeScanner" Class="mr-2">Scan</MudButton>
+                                <MudButton Variant="Variant.Filled" Color="Color.Info" OnClick="@(() => CompletePack(item))">Start Pack</MudButton>
+                            }
+                        </div>
+                    </MudPaper>
+                }
+                <div class="d-flex justify-end mt-4">
+                    <MudText Typo="Typo.body1" Class="mr-4">Total Weight: @GetTotalWeight(pickingList).ToString("N2") lbs</MudText>
+                    <MudButton Variant="Variant.Outlined" OnClick="@(() => PauseList(pickingList))" Class="mr-2">Pause List</MudButton>
+                    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@(() => CompletePacking(pickingList))">Complete Packing</MudButton>
+                </div>
+            </MudPaper>
         }
     </MudTabPanel>
 </MudTabs>
@@ -346,6 +392,17 @@
     private async Task ResumePack(PickingListItem item)
     {
         await PickingListService.ResumeTaskAsync(item.Id, TaskType.Packing, _userId!);
+        await LoadData();
+    }
+
+    private int GetPackedItemsCount(PickingList pickingList)
+    {
+        return pickingList.Items.Count(i => i.Packed);
+    }
+
+    private async Task CompletePacking(PickingList pickingList)
+    {
+        await PickingListService.CompletePackingAsync(pickingList.Id, _userId!);
         await LoadData();
     }
 

--- a/Components/Pages/Operations/PickingAndPacking.razor
+++ b/Components/Pages/Operations/PickingAndPacking.razor
@@ -178,32 +178,41 @@
     {
         get
         {
-            var lists = _pickingLists;
+            var lists = _pickingLists.Where(pl => pl.Status == PickingListStatus.Pending);
 
             if (!string.IsNullOrWhiteSpace(_searchTerm))
             {
                 lists = lists.Where(pl =>
                     pl.SalesOrderNumber.Contains(_searchTerm, StringComparison.OrdinalIgnoreCase) ||
                     (pl.Customer?.CustomerName?.Contains(_searchTerm, StringComparison.OrdinalIgnoreCase) ?? false)
-                ).ToList();
+                );
             }
 
             if (_selectedDestinationRegionId.HasValue)
             {
-                lists = lists.Where(pl => pl.DestinationRegionId == _selectedDestinationRegionId.Value).ToList();
+                lists = lists.Where(pl => pl.DestinationRegionId == _selectedDestinationRegionId.Value);
             }
 
             if (_selectedStatus.HasValue)
             {
-                lists = lists.Where(pl => pl.Status == _selectedStatus.Value).ToList();
+                lists = lists.Where(pl => pl.Status == _selectedStatus.Value);
             }
+            else
+            {
+                // Permanent filter for Pending status unless another status is selected
+                lists = lists.Where(pl => pl.Status == PickingListStatus.Pending);
+            }
+
 
             if (_selectedMachineCategory.HasValue)
             {
-                lists = lists.Where(pl => pl.Items.Any(i => i.Machine?.Category == _selectedMachineCategory.Value)).ToList();
+                lists = lists.Where(pl => pl.Items.Any(i => i.Machine?.Category == _selectedMachineCategory.Value));
             }
 
-            return lists;
+            // Filter out lists where all items are assigned to Sheet or Coil machines
+            lists = lists.Where(pl => !pl.Items.All(i => i.Machine != null && (i.Machine.Category == MachineCategory.Sheet || i.Machine.Category == MachineCategory.Coil)));
+
+            return lists.ToList();
         }
     }
 

--- a/Components/Pages/Operations/PickingAndPacking.razor
+++ b/Components/Pages/Operations/PickingAndPacking.razor
@@ -76,6 +76,11 @@
                         <MudText Typo="Typo.caption" Style="color:white;">@($"{GetPackingProgress(pickingList):F0}%")</MudText>
                     </MudProgressLinear>
                 </MudCardContent>
+                <MudCardActions>
+                    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@(() => SetActivePickingList(pickingList))" Disabled="@(ActivePickingListId == pickingList.Id || pickingList.Status != PickingListStatus.Pending)">
+                        @(ActivePickingListId == pickingList.Id ? "In Progress" : "Initiate Process")
+                    </MudButton>
+                </MudCardActions>
             </MudCard>
         }
     </MudTabPanel>
@@ -102,14 +107,25 @@
                                 <MudText Typo="Typo.body2">@item.Width" x @item.Length"</MudText>
                                 <MudText Typo="Typo.body2">Qty: @item.Quantity, Weight: @item.Weight</MudText>
                             </div>
-                            @if (item.Picked)
-                            {
-                                <MudChip T="string" Icon="@Icons.Material.Filled.Check" Color="Color.Success">Picked</MudChip>
-                            }
-                            else
-                            {
-                                <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@(() => StartPick(item))">Start Pick</MudButton>
-                            }
+                            <div>
+                                @if (item.Status == PickingLineStatus.Pending)
+                                {
+                                    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@(() => StartPickTask(item))" Disabled="@(ActivePickingListId != pickingList.Id)">Start Pick</MudButton>
+                                }
+                                else if (item.Status == PickingLineStatus.InProgress)
+                                {
+                                    <MudButton Variant="Variant.Filled" Color="Color.Warning" OnClick="@(() => PausePick(item))">Pause</MudButton>
+                                    <MudButton Variant="Variant.Filled" Color="Color.Success" OnClick="@(() => CompletePick(item))" Class="ml-2">Complete</MudButton>
+                                }
+                                else if (item.Status == PickingLineStatus.Paused)
+                                {
+                                    <MudButton Variant="Variant.Filled" Color="Color.Info" OnClick="@(() => ResumePick(item))">Resume</MudButton>
+                                }
+                                else if (item.Status == PickingLineStatus.Picked || item.Picked)
+                                {
+                                    <MudChip Icon="@Icons.Material.Filled.Check" Color="Color.Success">Picked</MudChip>
+                                }
+                            </div>
                         </MudPaper>
                     }
                 </MudCardContent>
@@ -139,14 +155,25 @@
                                 <MudText Typo="Typo.body2">@item.Width" x @item.Length"</MudText>
                                 <MudText Typo="Typo.body2">Qty: @item.Quantity, Weight: @item.Weight</MudText>
                             </div>
-                            @if (item.Packed)
-                            {
-                                <MudChip T="string" Icon="@Icons.Material.Filled.Check" Color="Color.Success">Packed</MudChip>
-                            }
-                            else
-                            {
-                                <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@(() => StartPack(item))">Start Pack</MudButton>
-                            }
+                            <div>
+                                @if (item.Status == PickingLineStatus.Picked && !item.Packed)
+                                {
+                                    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@(() => StartPackTask(item))" Disabled="@(ActivePickingListId != pickingList.Id)">Start Pack</MudButton>
+                                }
+                                else if (item.Status == PickingLineStatus.InProgress)
+                                {
+                                    <MudButton Variant="Variant.Filled" Color="Color.Warning" OnClick="@(() => PausePack(item))">Pause</MudButton>
+                                    <MudButton Variant="Variant.Filled" Color="Color.Success" OnClick="@(() => CompletePack(item))" Class="ml-2">Complete</MudButton>
+                                }
+                                else if (item.Status == PickingLineStatus.Paused)
+                                {
+                                    <MudButton Variant="Variant.Filled" Color="Color.Info" OnClick="@(() => ResumePack(item))">Resume</MudButton>
+                                }
+                                else if (item.Status == PickingLineStatus.Packed || item.Packed)
+                                {
+                                    <MudChip Icon="@Icons.Material.Filled.Check" Color="Color.Success">Packed</MudChip>
+                                }
+                            </div>
                         </MudPaper>
                     }
                 </MudCardContent>
@@ -163,6 +190,7 @@
     private int? _selectedDestinationRegionId;
     private PickingListStatus? _selectedStatus;
     private MachineCategory? _selectedMachineCategory;
+    private int? ActivePickingListId;
 
     private List<PickingList> FilteredPickingLists
     {
@@ -257,21 +285,47 @@
         StateHasChanged();
     }
 
-    private async Task StartPick(PickingListItem item)
+    private async Task SetActivePickingList(PickingList pickingList)
     {
-        var parameters = new DialogParameters { ["Item"] = item };
-        var dialog = await DialogService.ShowAsync<PickItemDialog>("Pick Item", parameters);
-        var result = await dialog.Result;
-
-        if (result is not null && !result.Canceled)
-        {
-            await PickingListService.ConfirmPickAsync(item.Id, _userId!);
-            await LoadData();
-        }
+        ActivePickingListId = pickingList.Id;
+        await PickingListService.InitiatePickingListProcessAsync(pickingList.Id, _userId!);
+        await LoadData();
     }
 
-    private async Task StartPack(PickingListItem item)
+    private async Task StartPickTask(PickingListItem item)
     {
+        await PickingListService.StartPickTaskAsync(item.Id, _userId!);
+        await LoadData();
+    }
+
+    private async Task CompletePick(PickingListItem item)
+    {
+        // This now acts as the 'Complete' button's action
+        await PickingListService.ConfirmPickAsync(item.Id, _userId!);
+        await LoadData();
+    }
+
+    private async Task PausePick(PickingListItem item)
+    {
+        await PickingListService.PauseTaskAsync(item.Id, TaskType.Picking, _userId!);
+        await LoadData();
+    }
+
+    private async Task ResumePick(PickingListItem item)
+    {
+        await PickingListService.ResumeTaskAsync(item.Id, TaskType.Picking, _userId!);
+        await LoadData();
+    }
+
+    private async Task StartPackTask(PickingListItem item)
+    {
+        await PickingListService.StartPackTaskAsync(item.Id, _userId!);
+        await LoadData();
+    }
+
+    private async Task CompletePack(PickingListItem item)
+    {
+        // This now acts as the 'Complete' button's action
         var parameters = new DialogParameters { ["Item"] = item };
         var dialog = await DialogService.ShowAsync<PackItemDialog>("Pack Item", parameters);
         var result = await dialog.Result;
@@ -281,6 +335,18 @@
             await PickingListService.ConfirmPackAsync(item.Id, _userId!, packResult.Quantity, packResult.ActualWeight, packResult.Notes);
             await LoadData();
         }
+    }
+
+    private async Task PausePack(PickingListItem item)
+    {
+        await PickingListService.PauseTaskAsync(item.Id, TaskType.Packing, _userId!);
+        await LoadData();
+    }
+
+    private async Task ResumePack(PickingListItem item)
+    {
+        await PickingListService.ResumeTaskAsync(item.Id, TaskType.Packing, _userId!);
+        await LoadData();
     }
 
     private int GetTotalLineItems(PickingList pickingList)

--- a/Components/Pages/Operations/PickingAndPacking.razor
+++ b/Components/Pages/Operations/PickingAndPacking.razor
@@ -1,11 +1,10 @@
 @page "/operations/picking-packing"
-@attribute [Microsoft.AspNetCore.Authorization.Authorize(Policy = "Permissions.PickingLists.View")]
-@attribute [Title("Pick and Pack")]
 @using CMetalsWS.Data
 @using CMetalsWS.Services
 @using System.Security.Claims
 @using CMetalsWS.Security
 @using Microsoft.AspNetCore.Components.Authorization
+@attribute [Authorize(Policy = Permissions.PickingLists.View)]
 
 @inject PickingListService PickingListService
 @inject ITaskAuditEventService AuditService
@@ -14,14 +13,12 @@
 @inject IDialogService DialogService
 @inject DestinationRegionService DestinationRegionService
 
+<PageTitle>Pick and Pack</PageTitle>
+
 <MudTabs Elevation="2" Rounded="true" PanelClass="mt-4">
     <MudTabPanel Text="Picking Lists">
         <MudPaper Class="pa-4 mb-4">
             <MudGrid Spacing="2">
-                <MudItem xs="12" sm="6">
-                    <MudText Typo="Typo.h6">Total Line Items: @TotalLineItems</MudText>
-                    <MudText Typo="Typo.h6">Total Weight: @TotalWeight.ToString("N2") lbs</MudText>
-                </MudItem>
                 <MudItem xs="12" sm="3">
                     <MudTextField @bind-Value="_searchTerm" Label="Search" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" />
                 </MudItem>
@@ -68,6 +65,8 @@
                 <MudCardContent>
                     <MudText>Destination: @pickingList.DestinationRegion?.Name</MudText>
                     <MudText>Ship Date: @pickingList.ShipDate?.ToShortDateString()</MudText>
+                    <MudText><b>Total Line Items (Sheet/Coil):</b> @GetTotalLineItems(pickingList)</MudText>
+                    <MudText><b>Total Weight (Sheet/Coil):</b> @GetTotalWeight(pickingList).ToString("N2") lbs</MudText>
                     <MudText Class="mt-2">Picking Progress</MudText>
                     <MudProgressLinear Color="Color.Primary" Value="@GetPickingProgress(pickingList)" Class="my-1">
                         <MudText Typo="Typo.caption" Style="color:white;">@($"{GetPickingProgress(pickingList):F0}%")</MudText>
@@ -178,8 +177,6 @@
     private PickingListStatus? _selectedStatus;
     private MachineCategory? _selectedMachineCategory;
 
-    private int TotalLineItems => FilteredPickingLists.SelectMany(pl => pl.Items).Count(i => i.Machine != null && (i.Machine.Category == MachineCategory.Sheet || i.Machine.Category == MachineCategory.Coil));
-    private decimal TotalWeight => FilteredPickingLists.SelectMany(pl => pl.Items).Where(i => i.Machine != null && (i.Machine.Category == MachineCategory.Sheet || i.Machine.Category == MachineCategory.Coil)).Sum(i => i.Weight ?? 0);
     private List<PickingList> FilteredPickingLists
     {
         get
@@ -299,6 +296,15 @@
         }
     }
 
+    private int GetTotalLineItems(PickingList pickingList)
+    {
+        return pickingList.Items.Count(i => i.Machine != null && (i.Machine.Category == MachineCategory.Sheet || i.Machine.Category == MachineCategory.Coil));
+    }
+
+    private decimal GetTotalWeight(PickingList pickingList)
+    {
+        return pickingList.Items.Where(i => i.Machine != null && (i.Machine.Category == MachineCategory.Sheet || i.Machine.Category == MachineCategory.Coil)).Sum(i => i.Weight ?? 0);
+    }
     private double GetPickingProgress(PickingList pickingList)
     {
         if (pickingList.Items == null || !pickingList.Items.Any())

--- a/Components/Pages/Operations/PickingAndPacking.razor
+++ b/Components/Pages/Operations/PickingAndPacking.razor
@@ -1,10 +1,12 @@
 @page "/operations/picking-packing"
+@attribute [Microsoft.AspNetCore.Authorization.Authorize(Policy = "Permissions.PickingLists.View")]
+@attribute [Title("Pick and Pack")]
 @using CMetalsWS.Data
 @using CMetalsWS.Services
 @using System.Security.Claims
 @using CMetalsWS.Security
 @using Microsoft.AspNetCore.Components.Authorization
-@attribute [Authorize(Policy = Permissions.PickingLists.View)]
+
 @inject PickingListService PickingListService
 @inject ITaskAuditEventService AuditService
 @inject ISnackbar Snackbar
@@ -12,12 +14,14 @@
 @inject IDialogService DialogService
 @inject DestinationRegionService DestinationRegionService
 
-<MudText Typo="Typo.h5" Class="mb-4">Picking & Packing</MudText>
-
 <MudTabs Elevation="2" Rounded="true" PanelClass="mt-4">
     <MudTabPanel Text="Picking Lists">
         <MudPaper Class="pa-4 mb-4">
             <MudGrid Spacing="2">
+                <MudItem xs="12" sm="6">
+                    <MudText Typo="Typo.h6">Total Line Items: @TotalLineItems</MudText>
+                    <MudText Typo="Typo.h6">Total Weight: @TotalWeight.ToString("N2") lbs</MudText>
+                </MudItem>
                 <MudItem xs="12" sm="3">
                     <MudTextField @bind-Value="_searchTerm" Label="Search" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" />
                 </MudItem>
@@ -174,6 +178,8 @@
     private PickingListStatus? _selectedStatus;
     private MachineCategory? _selectedMachineCategory;
 
+    private int TotalLineItems => FilteredPickingLists.SelectMany(pl => pl.Items).Count(i => i.Machine != null && (i.Machine.Category == MachineCategory.Sheet || i.Machine.Category == MachineCategory.Coil));
+    private decimal TotalWeight => FilteredPickingLists.SelectMany(pl => pl.Items).Where(i => i.Machine != null && (i.Machine.Category == MachineCategory.Sheet || i.Machine.Category == MachineCategory.Coil)).Sum(i => i.Weight ?? 0);
     private List<PickingList> FilteredPickingLists
     {
         get

--- a/Components/Pages/Operations/PickingAndPacking.razor
+++ b/Components/Pages/Operations/PickingAndPacking.razor
@@ -178,14 +178,23 @@
     {
         get
         {
-            var lists = _pickingLists.Where(pl => pl.Status == PickingListStatus.Pending);
+            var lists = _pickingLists.AsQueryable();
+
+            // Default to Pending status if no specific status is selected
+            if (!_selectedStatus.HasValue)
+            {
+                lists = lists.Where(pl => pl.Status == PickingListStatus.Pending);
+            }
+            else
+            {
+                lists = lists.Where(pl => pl.Status == _selectedStatus.Value);
+            }
 
             if (!string.IsNullOrWhiteSpace(_searchTerm))
             {
                 lists = lists.Where(pl =>
                     pl.SalesOrderNumber.Contains(_searchTerm, StringComparison.OrdinalIgnoreCase) ||
-                    (pl.Customer?.CustomerName?.Contains(_searchTerm, StringComparison.OrdinalIgnoreCase) ?? false)
-                );
+                    (pl.Customer != null && pl.Customer.CustomerName.Contains(_searchTerm, StringComparison.OrdinalIgnoreCase)));
             }
 
             if (_selectedDestinationRegionId.HasValue)
@@ -193,24 +202,17 @@
                 lists = lists.Where(pl => pl.DestinationRegionId == _selectedDestinationRegionId.Value);
             }
 
-            if (_selectedStatus.HasValue)
-            {
-                lists = lists.Where(pl => pl.Status == _selectedStatus.Value);
-            }
-            else
-            {
-                // Permanent filter for Pending status unless another status is selected
-                lists = lists.Where(pl => pl.Status == PickingListStatus.Pending);
-            }
-
-
             if (_selectedMachineCategory.HasValue)
             {
-                lists = lists.Where(pl => pl.Items.Any(i => i.Machine?.Category == _selectedMachineCategory.Value));
+                lists = lists.Where(pl => pl.Items.Any(i => i.Machine != null && i.Machine.Category == _selectedMachineCategory.Value));
             }
 
-            // Filter out lists where all items are assigned to Sheet or Coil machines
-            lists = lists.Where(pl => !pl.Items.All(i => i.Machine != null && (i.Machine.Category == MachineCategory.Sheet || i.Machine.Category == MachineCategory.Coil)));
+            // Exclude lists where all items assigned to Sheet or Coil are packed
+            lists = lists.Where(pl =>
+                !pl.Items
+                    .Where(i => i.Machine != null && (i.Machine.Category == MachineCategory.Sheet || i.Machine.Category == MachineCategory.Coil))
+                    .All(i => i.Status == PickingLineStatus.Packed)
+            );
 
             return lists.ToList();
         }

--- a/Components/Pages/Operations/PickingAndPacking.razor
+++ b/Components/Pages/Operations/PickingAndPacking.razor
@@ -58,8 +58,8 @@
                         <MudText Typo="Typo.body2">@pickingList.Customer?.CustomerName</MudText>
                     </CardHeaderContent>
                     <CardHeaderActions>
-                        <MudChip T="string" Color="@(GetPriorityColor(pickingList.Priority))">@GetPriorityText(pickingList.Priority)</MudChip>
-                        <MudChip T="string" Color="Color.Default">@pickingList.Status.ToString()</MudChip>
+                        <MudChip T="string" Color="@(GetPriorityColor(pickingList.Priority))" Value="@GetPriorityText(pickingList.Priority)">@GetPriorityText(pickingList.Priority)</MudChip>
+                        <MudChip T="string" Color="Color.Default" Value="@pickingList.Status.ToString()">@pickingList.Status.ToString()</MudChip>
                     </CardHeaderActions>
                 </MudCardHeader>
                 <MudCardContent>
@@ -94,8 +94,8 @@
                         <MudText Typo="Typo.body2">@pickingList.Customer?.CustomerName</MudText>
                     </CardHeaderContent>
                     <CardHeaderActions>
-                        <MudChip T="string" Color="@(GetPriorityColor(pickingList.Priority))">@GetPriorityText(pickingList.Priority)</MudChip>
-                        <MudChip T="string" Color="Color.Default">@pickingList.Status.ToString()</MudChip>
+                        <MudChip T="string" Color="@(GetPriorityColor(pickingList.Priority))" Value="@GetPriorityText(pickingList.Priority)">@GetPriorityText(pickingList.Priority)</MudChip>
+                        <MudChip T="string" Color="Color.Default" Value="@pickingList.Status.ToString()">@pickingList.Status.ToString()</MudChip>
                     </CardHeaderActions>
                 </MudCardHeader>
                 <MudCardContent>
@@ -123,7 +123,7 @@
                                 }
                                 else if (item.Status == PickingLineStatus.Picked || item.Picked)
                                 {
-                                    <MudChip Icon="@Icons.Material.Filled.Check" Color="Color.Success">Picked</MudChip>
+                                    <MudChip T="string" Icon="@Icons.Material.Filled.Check" Color="Color.Success">Picked</MudChip>
                                 }
                             </div>
                         </MudPaper>
@@ -142,8 +142,8 @@
                         <MudText Typo="Typo.body2">@pickingList.Customer?.CustomerName</MudText>
                     </CardHeaderContent>
                     <CardHeaderActions>
-                        <MudChip T="string" Color="@(GetPriorityColor(pickingList.Priority))">@GetPriorityText(pickingList.Priority)</MudChip>
-                        <MudChip T="string" Color="Color.Default">@pickingList.Status.ToString()</MudChip>
+                        <MudChip T="string" Color="@(GetPriorityColor(pickingList.Priority))" Value="@GetPriorityText(pickingList.Priority)">@GetPriorityText(pickingList.Priority)</MudChip>
+                        <MudChip T="string" Color="Color.Default" Value="@pickingList.Status.ToString()">@pickingList.Status.ToString()</MudChip>
                     </CardHeaderActions>
                 </MudCardHeader>
                 <MudCardContent>
@@ -171,7 +171,7 @@
                                 }
                                 else if (item.Status == PickingLineStatus.Packed || item.Packed)
                                 {
-                                    <MudChip Icon="@Icons.Material.Filled.Check" Color="Color.Success">Packed</MudChip>
+                                    <MudChip T="string" Icon="@Icons.Material.Filled.Check" Color="Color.Success">Packed</MudChip>
                                 }
                             </div>
                         </MudPaper>

--- a/Components/Pages/Operations/PickingAndPacking.razor
+++ b/Components/Pages/Operations/PickingAndPacking.razor
@@ -94,7 +94,7 @@
                     </CardHeaderActions>
                 </MudCardHeader>
                 <MudCardContent>
-                    @foreach (var item in pickingList.Items)
+                    @foreach (var item in pickingList.Items.Where(i => i.Machine != null && (i.Machine.Category == MachineCategory.Sheet || i.Machine.Category == MachineCategory.Coil)))
                     {
                         <MudPaper Class="d-flex align-center pa-2 mb-2">
                             <div class="flex-grow-1">
@@ -131,7 +131,7 @@
                     </CardHeaderActions>
                 </MudCardHeader>
                 <MudCardContent>
-                    @foreach (var item in pickingList.Items.Where(i => i.Picked))
+                    @foreach (var item in pickingList.Items.Where(i => i.Picked && i.Machine != null && (i.Machine.Category == MachineCategory.Sheet || i.Machine.Category == MachineCategory.Coil)))
                     {
                         <MudPaper Class="d-flex align-center pa-2 mb-2">
                             <div class="flex-grow-1">
@@ -152,19 +152,6 @@
                 </MudCardContent>
             </MudCard>
         }
-    </MudTabPanel>
-    <MudTabPanel Text="By Destination">
-        <MudExpansionPanels>
-            @foreach (var group in FilteredPickingLists.GroupBy(pl => pl.DestinationRegion?.Name))
-            {
-                <MudExpansionPanel Text="@group.Key">
-                    @foreach (var pickingList in group)
-                    {
-                        <MudText>@pickingList.SalesOrderNumber - @pickingList.Customer?.CustomerName</MudText>
-                    }
-                </MudExpansionPanel>
-            }
-        </MudExpansionPanels>
     </MudTabPanel>
 </MudTabs>
 

--- a/Components/Pages/Operations/PickingAndPacking.razor
+++ b/Components/Pages/Operations/PickingAndPacking.razor
@@ -180,22 +180,35 @@
         {
             var lists = _pickingLists.AsQueryable();
 
-            // Default to Pending status if no specific status is selected
-            if (!_selectedStatus.HasValue)
-            {
-                lists = lists.Where(pl => pl.Status == PickingListStatus.Pending);
-            }
-            else
-            {
-                lists = lists.Where(pl => pl.Status == _selectedStatus.Value);
-            }
-
             if (!string.IsNullOrWhiteSpace(_searchTerm))
             {
-                lists = lists.Where(pl =>
+                // If searching, first filter by search term across all lists
+                var searchFilteredLists = lists.Where(pl =>
                     pl.SalesOrderNumber.Contains(_searchTerm, StringComparison.OrdinalIgnoreCase) ||
                     (pl.Customer != null && pl.Customer.CustomerName.Contains(_searchTerm, StringComparison.OrdinalIgnoreCase)));
+
+                // If the search is for a sales order, return it regardless of status
+                if (int.TryParse(_searchTerm, out _) || _searchTerm.StartsWith("SO", StringComparison.OrdinalIgnoreCase))
+                {
+                     return searchFilteredLists.ToList();
+                }
+
+                lists = searchFilteredLists;
             }
+
+            // Apply status filter only if not searching for a specific sales order
+            if (string.IsNullOrWhiteSpace(_searchTerm) || !(int.TryParse(_searchTerm, out _) || _searchTerm.StartsWith("SO", StringComparison.OrdinalIgnoreCase)))
+            {
+                if (!_selectedStatus.HasValue)
+                {
+                    lists = lists.Where(pl => pl.Status == PickingListStatus.Pending);
+                }
+                else
+                {
+                    lists = lists.Where(pl => pl.Status == _selectedStatus.Value);
+                }
+            }
+
 
             if (_selectedDestinationRegionId.HasValue)
             {

--- a/Data/Enumerations.cs
+++ b/Data/Enumerations.cs
@@ -30,7 +30,9 @@
         Completed,
         Canceled,
         WorkOrder,
-        Awaiting
+        Awaiting,
+        Picked,
+        Packed
     }
 
     public enum TaskType

--- a/Data/Enumerations.cs
+++ b/Data/Enumerations.cs
@@ -32,7 +32,8 @@
         WorkOrder,
         Awaiting,
         Picked,
-        Packed
+        Packed,
+        Paused
     }
 
     public enum TaskType

--- a/Services/PickingListService.cs
+++ b/Services/PickingListService.cs
@@ -501,7 +501,7 @@ namespace CMetalsWS.Services
             item.Picked = true;
             item.PickedById = userId;
             item.PickedAt = DateTime.UtcNow;
-            item.Status = PickingLineStatus.InProgress;
+            item.Status = PickingLineStatus.Picked;
             await _auditService.CreateAuditEventAsync(itemId, TaskType.Picking, AuditEventType.Complete, userId);
 
             await db.SaveChangesAsync();
@@ -524,7 +524,7 @@ namespace CMetalsWS.Services
             }
             item.ActualWeight = actualWeight;
             item.PackingNotes = notes;
-            item.Status = PickingLineStatus.Completed;
+            item.Status = PickingLineStatus.Packed;
             await _auditService.CreateAuditEventAsync(itemId, TaskType.Packing, AuditEventType.Complete, userId);
 
             await db.SaveChangesAsync();


### PR DESCRIPTION
This commit introduces a permanent filter to the Picking & Packing page.

- The picking list view now only shows lists with a 'Pending' status by default.
- Lists where all items are assigned to 'Sheet' or 'Coil' machines are now hidden.
- Added 'Picked' and 'Packed' statuses to the 'PickingLineStatus' enum.
- The picking and packing logic now uses these new statuses.