### PR TITLE
Fix CS0023 by making WorkOrder.DueDate nullable

### DIFF
--- a/Data/WorkOrder.cs
+++ b/Data/WorkOrder.cs
@@ -44,7 +44,7 @@ namespace CMetalsWS.Data
 
         public MachineCategory MachineCategory { get; set; }
 
-        public DateTime DueDate { get; set; }
+        public DateTime? DueDate { get; set; }
 
         public string? ParentItemId { get; set; }
         public string? ParentItemDescription { get; set; }


### PR DESCRIPTION
The compiler was throwing error CS0023 because the null-conditional operator `?.` was being used on the `DueDate` property of the `WorkOrder` class, which was a non-nullable `DateTime`.

This change modifies the `WorkOrder` model in `Data/WorkOrder.cs` to make the `DueDate` property a nullable `DateTime?`. This resolves the compilation error in `Services/WorkOrderService.cs` where the property was being treated as nullable.