### PR TITLE
Fix: Correct navigation for 'Process Work Order' button

### DIFF
--- a/Components/Pages/Operations/WorkOrder/WorkOrderDetailsDialog.razor
+++ b/Components/Pages/Operations/WorkOrder/WorkOrderDetailsDialog.razor
@@ -71,7 +71,6 @@
 
     private void GoToProcessPage()
     {
-        Navigation.NavigateTo($"/operations/workorder/process/{Model.Id}");
         MudDialog.Close(DialogResult.Ok(true));
     }
 

--- a/Components/Pages/Operations/WorkOrder/WorkOrderPage.razor
+++ b/Components/Pages/Operations/WorkOrder/WorkOrderPage.razor
@@ -1,5 +1,6 @@
 @page "/operations/workorder/manage"
 @page "/operations/workorder/manage/{Id:int}"
+@page "/operations/workorder/process/{Id:int}"
 @using CMetalsWS.Data
 @using CMetalsWS.Services
 @using Microsoft.AspNetCore.Components.Authorization

--- a/Components/Pages/Schedule/MachineScheduleBase.razor
+++ b/Components/Pages/Schedule/MachineScheduleBase.razor
@@ -141,7 +141,13 @@
 
         var parameters = new DialogParameters { ["Model"] = scheduleEvent.WorkOrder };
         var options = new DialogOptions { MaxWidth = MaxWidth.Medium, FullWidth = true };
-        await DialogService.ShowAsync<WorkOrderDetailsDialog>("Work Order Details", parameters, options);
+        var dialog = await DialogService.ShowAsync<WorkOrderDetailsDialog>("Work Order Details", parameters, options);
+        var result = await dialog.Result;
+
+        if (result is not null && !result.Canceled)
+        {
+            NavigationManager.NavigateTo($"/operations/workorder/process/{scheduleEvent.WorkOrder.Id}");
+        }
     }
 
     private async Task OnItemChanged(CalendarItem item)


### PR DESCRIPTION
The 'Process Work Order' button in `WorkOrderDetailsDialog.razor` was causing navigation to the home page instead of the process page. This was due to the dialog closing immediately after the navigation was initiated, interrupting the action.

The fix involves moving the navigation logic from the dialog to the parent component (`MachineScheduleBase.razor`). The dialog now closes and returns a result, and the parent component handles the navigation upon receiving a successful result.