### PR TITLE
Feat: Enhance Pickup Dialog with Checkbox, Layout, and Validation

### DIFF
--- a/Components/Pages/Planning/RecordPickupDialog.razor
+++ b/Components/Pages/Planning/RecordPickupDialog.razor
@@ -135,6 +135,17 @@
             Snackbar.Add("No pickup quantities were entered.", Severity.Info);
             return;
         }
+
+        foreach (var pickup in _pickupsToConfirm)
+        {
+            var item = pickup.Key;
+            if (item.Status != "Packed" && item.Status != "Completed")
+            {
+                Snackbar.Add($"Item '{item.Description}' cannot be picked up. Status must be 'Packed' or 'Completed', but is '{item.Status}'.", Severity.Error);
+                return;
+            }
+        }
+
         _isConfirming = true;
     }
 


### PR DESCRIPTION
This commit introduces several UI enhancements and validation logic to the `RecordPickupDialog.razor` component to improve usability and prevent errors.

The new functionality includes:
- A checkbox that is synchronized with the "Pickup Now" input field. Checking the box sets the quantity to the full remaining amount, and unchecking it sets the quantity to zero.
- The dialog has been made wider (`MaxWidth.Large`, `FullWidth = true`) to better accommodate the content.
- The checkbox has been relocated to appear directly in front of the item description for a more intuitive layout.
- Validation has been added to the `ProceedToConfirm` method to ensure that only items with a status of "Packed" or "Completed" can be picked up. An error snackbar is shown if the validation fails.

This commit also resolves a persistent UI rendering issue by implementing a robust state management pattern based on a working example from `LoadCreationSimplified.razor`. The fix includes:
- Using the correct `Value` and `ValueChanged` properties on the `MudCheckBox` component.
- Using a single dictionary, `_pickupQuantities`, as the single source of truth for the state of the input fields.
- Adding a `@key` attribute to the `MudPaper` component within the `foreach` loop to ensure Blazor correctly tracks and re-renders each item.
- Calling `StateHasChanged()` in the event handlers to force immediate UI updates.
- Adding logic to correctly calculate the remaining quantity, using the full order quantity if nothing has been picked up yet.

These changes ensure a robust and reliable synchronization between the checkbox and the numeric field, providing a correct and seamless user experience.