### PR TITLE
feat: Add status validation to customer pickup workflow

### DIFF
--- a/Components/Pages/Planning/CustomerPickupManagement.razor
+++ b/Components/Pages/Planning/CustomerPickupManagement.razor
@@ -56,6 +56,19 @@
 
     private async Task ManagePickup(AvailableOrder order)
     {
+        if (!int.TryParse(order.Id, out var orderId))
+        {
+            Snackbar.Add("Error: Invalid Order ID.", Severity.Error);
+            return;
+        }
+
+        var validationResult = await FulfillmentService.ValidateOrderForPickup(orderId);
+        if (!validationResult.IsValid)
+        {
+            Snackbar.Add(validationResult.ErrorMessage, Severity.Error, config => { config.VisibleStateDuration = 5000; });
+            return;
+        }
+
         var selectionDialog = await DialogService.ShowAsync<PickupTypeSelectionDialog>("Select Pickup Type");
         var selectionResult = await selectionDialog.Result;
 

--- a/Components/Pages/Planning/RecordPickupDialog.razor
+++ b/Components/Pages/Planning/RecordPickupDialog.razor
@@ -79,7 +79,7 @@
         else
         {
             <MudButton OnClick="Cancel">Cancel</MudButton>
-            <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="ProceedToConfirm">Record Pickup</MudButton>
+            <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="async () => await ProceedToConfirm()">Record Pickup</MudButton>
         }
     </DialogActions>
 </MudDialog>
@@ -121,8 +121,23 @@
         StateHasChanged();
     }
 
-    private void ProceedToConfirm()
+    private async Task ProceedToConfirm()
     {
+        if (!int.TryParse(Order.Id, out var orderId))
+        {
+            Snackbar.Add("Error: Invalid Order ID.", Severity.Error);
+            return;
+        }
+
+        var validationResult = await FulfillmentService.ValidateOrderForPickup(orderId);
+        if (!validationResult.IsValid)
+        {
+            Snackbar.Add(validationResult.ErrorMessage, Severity.Error, config => { config.VisibleStateDuration = 5000; });
+            // Optionally close the dialog if the order is fundamentally invalid now.
+            // MudDialog.Cancel();
+            return;
+        }
+
         _pickupsToConfirm = _pickupQuantities
             .Where(kvp => kvp.Value > 0)
             .ToDictionary(
@@ -136,15 +151,8 @@
             return;
         }
 
-        foreach (var pickup in _pickupsToConfirm)
-        {
-            var item = pickup.Key;
-            if (item.Status != "Packed" && item.Status != "Completed")
-            {
-                Snackbar.Add($"Item '{item.Description}' cannot be picked up. Status must be 'Packed' or 'Completed', but is '{item.Status}'.", Severity.Error);
-                return;
-            }
-        }
+        // The validation logic is now centralized in the service, but we can keep this as a secondary client-side check if desired.
+        // Or rely solely on the service call. For this implementation, we'll rely on the service call and remove the redundant loop.
 
         _isConfirming = true;
     }


### PR DESCRIPTION
This commit introduces a new validation mechanism to the customer pickup workflow. A centralized validation method, `ValidateOrderForPickup`, has been added to the `FulfillmentService`. This method checks that all items in an order are in a 'Packed' or 'Completed' status before allowing a pickup to be recorded.

This check is now invoked from two key locations:
1.  In `CustomerPickupManagement.razor`, when the 'Manage Pickup' button is clicked.
2.  In `RecordPickupDialog.razor`, when the 'Record Pickup' button is clicked to proceed to the confirmation screen.

If the validation fails at either point, the user is presented with a descriptive error message in a snackbar, and the action is aborted. This prevents users from attempting to pick up items that are not in a valid state, improving data consistency and preventing potential downstream issues in the logistics process.